### PR TITLE
Add trace message to custom properties #28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog 
 
+### Version 2.1.0
+
+- For NLog and Log4Net when exception is traced with a custom message, custom message is added to the properties collection and reported to ApplicationInsights.
+
 ### Version 2.0.0
 
 - Update Application Insights API reference to [2.0.0](https://github.com/Microsoft/ApplicationInsights-dotnet/releases/tag/v2.0.0)

--- a/src/Adapters.Tests/Log4NetAppender.Tests.Shared/ApplicationInsightsAppenderTests.cs
+++ b/src/Adapters.Tests/Log4NetAppender.Tests.Shared/ApplicationInsightsAppenderTests.cs
@@ -297,6 +297,25 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
             Assert.AreEqual(expectedException.Message, telemetry.Exception.Message);
         }
 
+        [TestMethod]
+        [TestCategory("Log4NetAppender")]
+        public void CustomMessageIsAddedToExceptionTelemetryCustomProperties()
+        {
+            ILog logger = this.appendableLogger.Logger;
+
+            try
+            {
+                throw new Exception("Test logging exception");
+            }
+            catch (Exception exception)
+            {
+                logger.Error("custom message", exception);
+            }
+
+            ExceptionTelemetry telemetry = (ExceptionTelemetry)this.appendableLogger.SentItems.First();
+            Assert.IsTrue(telemetry.Properties["Message"].StartsWith("custom message"));
+        }
+
         internal static void InitializeLog4NetAIAdapter(string adapterComponentIdSnippet)
         {
             string xmlRawText =

--- a/src/Adapters.Tests/NLogTarget.Tests.Shared/NLogTargetTests.cs
+++ b/src/Adapters.Tests/NLogTarget.Tests.Shared/NLogTargetTests.cs
@@ -232,8 +232,27 @@
                 aiLogger.Debug(exception, "testing exception scenario");
             }
 
-            var telemetry = (ExceptionTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
+            var telemetry = (ExceptionTelemetry)this.adapterHelper.Channel.SentItems.First();
             Assert.AreEqual(expectedException.Message, telemetry.Exception.Message);
+        }
+
+        [TestMethod]
+        [TestCategory("NLogTarget")]
+        public void CustomMessageIsAddedToExceptionTelemetryCustomProperties()
+        {
+            Logger aiLogger = this.CreateTargetWithGivenInstrumentationKey();
+            
+            try
+            {
+                throw new Exception("Test logging exception");
+            }
+            catch (Exception exception)
+            {
+                aiLogger.Debug(exception, "custom message");
+            }
+
+            ExceptionTelemetry telemetry = (ExceptionTelemetry)this.adapterHelper.Channel.SentItems.First();
+            Assert.IsTrue(telemetry.Properties["Message"].StartsWith("custom message"));
         }
 
         [TestMethod]

--- a/src/Adapters/Log4NetAppender.Shared/ApplicationInsightsAppender.cs
+++ b/src/Adapters/Log4NetAppender.Shared/ApplicationInsightsAppender.cs
@@ -83,7 +83,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender
 
         private static void AddLoggingEventProperty(string key, string value, IDictionary<string, string> metaData)
         {
-            if (value != null)
+            if (value != null && !metaData.ContainsKey(key))
             {
                 metaData.Add(key, value);
             }
@@ -97,6 +97,17 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender
                 {
                     SeverityLevel = this.GetSeverityLevel(loggingEvent.Level)
                 };
+
+                string message = null;
+                if (loggingEvent.RenderedMessage != null)
+                {
+                    message = this.RenderLoggingEvent(loggingEvent);
+                }
+
+                if (!string.IsNullOrEmpty(message))
+                {
+                    exceptionTelemetry.Properties.Add("Message", message);
+                }
 
                 this.BuildCustomProperties(loggingEvent, exceptionTelemetry);
                 this.telemetryClient.Track(exceptionTelemetry);

--- a/src/Adapters/NLogTarget.Shared/ApplicationInsightsTarget.cs
+++ b/src/Adapters/NLogTarget.Shared/ApplicationInsightsTarget.cs
@@ -93,6 +93,9 @@ namespace Microsoft.ApplicationInsights.NLogTarget
                 SeverityLevel = this.GetSeverityLevel(logEvent.Level)
             };
 
+            string logMessage = this.Layout.Render(logEvent);
+            exceptionTelemetry.Properties.Add("Message", logMessage);
+
             this.BuildPropertyBag(logEvent, exceptionTelemetry);
             this.telemetryClient.Track(exceptionTelemetry);
         }


### PR DESCRIPTION
To resolve #28 : in this version we will add custom trace message to custom properties.
After we update to Core SDK 2.2 we can switch: add exception message in custom properties and trace message use as main exception telemetry message. (To allow this there was a change in Core SDK: https://github.com/Microsoft/ApplicationInsights-dotnet/pull/242 )