### PR TITLE
Fix unit tests failure due to racing condition

### DIFF
--- a/src/Adapters.Tests/Etw.Net451.Tests/Etw.Net451.Tests.csproj
+++ b/src/Adapters.Tests/Etw.Net451.Tests/Etw.Net451.Tests.csproj
@@ -33,6 +33,7 @@
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+    <Reference Include="System.Security" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EtwTelemetryModuleTests.cs" />

--- a/src/Adapters.Tests/Etw.Net451.Tests/EtwTelemetryModuleTests.cs
+++ b/src/Adapters.Tests/Etw.Net451.Tests/EtwTelemetryModuleTests.cs
@@ -94,8 +94,8 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
         public void InitializeFailedWhenSourceIsNotSpecified()
         {
             using (EventSourceModuleDiagnosticListener listener = new EventSourceModuleDiagnosticListener())
-            using (TraceEventSessionMock traceEventSession = new TraceEventSessionMock(true, false))
-            using (EtwTelemetryModule module = new EtwTelemetryModule(traceEventSession, (t, c) => { }))
+            using (TraceEventSessionMock traceEventSession = new TraceEventSessionMock(false))
+            using (EtwTelemetryModule module = new EtwTelemetryModule(() => traceEventSession))
             {
                 module.Initialize(GetTestTelemetryConfiguration());
                 Assert.AreEqual(1, listener.EventsReceived.Count);
@@ -109,8 +109,8 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
         public void InitializeFailedWhenAccessDenied()
         {
             using (EventSourceModuleDiagnosticListener listener = new EventSourceModuleDiagnosticListener())
-            using (TraceEventSessionMock traceEventSession = new TraceEventSessionMock(true, true))
-            using (EtwTelemetryModule module = new EtwTelemetryModule(traceEventSession, (t, c) => { }))
+            using (TraceEventSessionMock traceEventSession = new TraceEventSessionMock(true))
+            using (EtwTelemetryModule module = new EtwTelemetryModule(() => traceEventSession))
             {
                 module.Sources.Add(new EtwListeningRequest()
                 {
@@ -129,8 +129,8 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
         public void InitializeSucceed()
         {
             using (EventSourceModuleDiagnosticListener listener = new EventSourceModuleDiagnosticListener())
-            using (TraceEventSessionMock traceEventSession = new TraceEventSessionMock(true, false))
-            using (EtwTelemetryModule module = new EtwTelemetryModule(traceEventSession, (t, c) => { }))
+            using (TraceEventSessionMock traceEventSession = new TraceEventSessionMock(false))
+            using (EtwTelemetryModule module = new EtwTelemetryModule(() => traceEventSession))
             {
                 module.Sources.Add(new EtwListeningRequest()
                 {
@@ -147,8 +147,8 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
         public void ProviderEnabledByName()
         {
             using (EventSourceModuleDiagnosticListener listener = new EventSourceModuleDiagnosticListener())
-            using (TraceEventSessionMock traceEventSession = new TraceEventSessionMock(true, false))
-            using (EtwTelemetryModule module = new EtwTelemetryModule(traceEventSession, (t, c) => { }))
+            using (TraceEventSessionMock traceEventSession = new TraceEventSessionMock(false))
+            using (EtwTelemetryModule module = new EtwTelemetryModule(() => traceEventSession))
             {
                 module.Sources.Add(new EtwListeningRequest()
                 {
@@ -166,8 +166,8 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
         public void ProviderEnabledByGuid()
         {
             using (EventSourceModuleDiagnosticListener listener = new EventSourceModuleDiagnosticListener())
-            using (TraceEventSessionMock traceEventSession = new TraceEventSessionMock(true, false))
-            using (EtwTelemetryModule module = new EtwTelemetryModule(traceEventSession, (t, c) => { }))
+            using (TraceEventSessionMock traceEventSession = new TraceEventSessionMock(false))
+            using (EtwTelemetryModule module = new EtwTelemetryModule(() => traceEventSession))
             {
                 Guid guid = Guid.NewGuid();
                 module.Sources.Add(new EtwListeningRequest()
@@ -186,8 +186,8 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
         public void ProviderNotEnabledByEmptyGuid()
         {
             using (EventSourceModuleDiagnosticListener listener = new EventSourceModuleDiagnosticListener())
-            using (TraceEventSessionMock traceEventSession = new TraceEventSessionMock(true, false))
-            using (EtwTelemetryModule module = new EtwTelemetryModule(traceEventSession, (t, c) => { }))
+            using (TraceEventSessionMock traceEventSession = new TraceEventSessionMock(false))
+            using (EtwTelemetryModule module = new EtwTelemetryModule(() => traceEventSession))
             {
                 Guid guid = Guid.Empty;
                 module.Sources.Add(new EtwListeningRequest()

--- a/src/Adapters.Tests/Etw.Net451.Tests/TraceEventSessionMock.cs
+++ b/src/Adapters.Tests/Etw.Net451.Tests/TraceEventSessionMock.cs
@@ -14,7 +14,6 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
 
     internal class TraceEventSessionMock : ITraceEventSession
     {
-        private bool? isElevated;
         private bool isFakeAccessDenied;
 
         public List<string> EnabledProviderNames { get; private set; }
@@ -22,19 +21,18 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
 
 
         public TraceEventSessionMock()
-            : this(true, false)
+            : this(false)
         {
         }
 
-        public TraceEventSessionMock(bool? fakeElevatedStatus, bool fakeAccessDeniedOnEnablingProvider)
+        public TraceEventSessionMock(bool fakeAccessDeniedOnEnablingProvider)
         {
             this.EnabledProviderNames = new List<string>();
             this.EnabledProviderGuids = new List<Guid>();
-            this.isElevated = fakeElevatedStatus;
             this.isFakeAccessDenied = fakeAccessDeniedOnEnablingProvider;
         }
 
-        public ETWTraceEventSource Source { get; private set; }
+        public TraceEventDispatcher Source { get; private set; }
 
         public void DisableProvider(Guid providerGuid)
         {
@@ -76,11 +74,6 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
             }
             this.EnabledProviderNames.Add(providerName);
             return true;
-        }
-
-        public bool? IsElevated()
-        {
-            return this.isElevated;
         }
 
         public bool Stop(bool noThrow = false)

--- a/src/Adapters.Tests/Shared/CustomTelemetryChannel.cs
+++ b/src/Adapters.Tests/Shared/CustomTelemetryChannel.cs
@@ -7,14 +7,19 @@
 
 namespace Microsoft.ApplicationInsights
 {
+    using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
-
     internal class CustomTelemetryChannel : ITelemetryChannel
     {
+        private EventWaitHandle waitHandle;
+
         public CustomTelemetryChannel()
         {
+            this.waitHandle = new AutoResetEvent(false);
             this.SentItems = new ITelemetry[0];
         }
 
@@ -32,7 +37,13 @@ namespace Microsoft.ApplicationInsights
                 List<ITelemetry> temp = new List<ITelemetry>(current);
                 temp.Add(item);
                 this.SentItems = temp.ToArray();
+                this.waitHandle.Set();
             }
+        }
+
+        public Task WaitOneItemAsync(TimeSpan timeout)
+        {
+            return Task.Factory.StartNew(() => this.waitHandle.WaitOne(timeout));
         }
 
         public void Flush()
@@ -46,7 +57,7 @@ namespace Microsoft.ApplicationInsights
 
         public CustomTelemetryChannel Reset()
         {
-            lock(this)
+            lock (this)
             {
                 this.SentItems = new ITelemetry[0];
             }

--- a/src/Adapters/Etw.Net451/AITraceEventSession.cs
+++ b/src/Adapters/Etw.Net451/AITraceEventSession.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ApplicationInsights.EtwCollector
             this.session = traceEventSession;
         }
 
-        public ETWTraceEventSource Source
+        public TraceEventDispatcher Source
         {
             get
             {

--- a/src/Adapters/Etw.Net451/EtwTelemetryModule.cs
+++ b/src/Adapters/Etw.Net451/EtwTelemetryModule.cs
@@ -30,38 +30,38 @@ namespace Microsoft.ApplicationInsights.EtwCollector
         private List<Guid> enabledProviderIds;
         private List<string> enabledProviderNames;
         private ITraceEventSession traceEventSession;
-        private Action<ITraceEventSession, TelemetryClient> startTraceEventSession;
+        private Func<ITraceEventSession> traceEventSessionFactory;
 
         /// <summary>
         /// EtwTelemetryModule default constructor.
         /// </summary>
-        public EtwTelemetryModule() : this(
-            new AITraceEventSession(new TraceEventSession(string.Format(CultureInfo.InvariantCulture, "ApplicationInsights-{0}-{1}", nameof(EtwTelemetryModule), Guid.NewGuid()))),
-            new Action<ITraceEventSession, TelemetryClient>((traceSession, client) =>
-            {
-                if (traceSession != null && traceSession.Source != null)
-                {
-                    traceSession.Source.Dynamic.All += traceEvent =>
-                    {
-                        traceEvent.Track(client);
-                    };
-                    Task.Factory.StartNew(() => traceSession.Source.Process(), TaskCreationOptions.LongRunning);
-                }
-            }))
+        public EtwTelemetryModule()
+            : this(() => new AITraceEventSession(new TraceEventSession(
+             string.Format(
+                 CultureInfo.InvariantCulture,
+                 "ApplicationInsights-{0}-{1}",
+                 nameof(EtwTelemetryModule),
+                 Guid.NewGuid()))))
         {
         }
 
-        internal EtwTelemetryModule(
-            ITraceEventSession traceEventSession,
-            Action<ITraceEventSession, TelemetryClient> startTraceEventSessionAction)
+        internal EtwTelemetryModule(Func<ITraceEventSession> traceEventSessionFactory)
         {
             this.lockObject = new object();
             this.Sources = new List<EtwListeningRequest>();
             this.enabledProviderIds = new List<Guid>();
             this.enabledProviderNames = new List<string>();
 
-            this.traceEventSession = traceEventSession;
-            this.startTraceEventSession = startTraceEventSessionAction;
+            if (traceEventSessionFactory == null)
+            {
+                throw new ArgumentNullException(nameof(traceEventSessionFactory));
+            }
+            this.traceEventSessionFactory = traceEventSessionFactory;
+        }
+
+        private void OnEvent(TraceEvent traceEvent)
+        {
+            traceEvent.Track(this.client);
         }
 
         /// <summary>
@@ -117,6 +117,11 @@ namespace Microsoft.ApplicationInsights.EtwCollector
                     return;
                 }
 
+                if (this.traceEventSession == null)
+                {
+                    this.traceEventSession = this.traceEventSessionFactory();
+                }
+
                 this.EnableProviders();
 
                 if (!this.isInitialized)
@@ -124,7 +129,16 @@ namespace Microsoft.ApplicationInsights.EtwCollector
                     try
                     {
                         // Start the trace session
-                        this.startTraceEventSession(this.traceEventSession, this.client);
+                        if (this.traceEventSession != null && this.traceEventSession.Source != null && this.traceEventSession.Source.Dynamic != null)
+                        {
+                            this.traceEventSession.Source.Dynamic.All += this.OnEvent;
+                            Task.Factory.StartNew(() =>
+                            {
+                                this.traceEventSession.Source.Process();
+                                this.traceEventSession.Source.Dynamic.All -= this.OnEvent;
+                                this.isInitialized = false;
+                            }, TaskCreationOptions.LongRunning);
+                        }
                     }
                     finally
                     {

--- a/src/Adapters/Etw.Net451/EtwTelemetryModule.cs
+++ b/src/Adapters/Etw.Net451/EtwTelemetryModule.cs
@@ -59,11 +59,6 @@ namespace Microsoft.ApplicationInsights.EtwCollector
             this.traceEventSessionFactory = traceEventSessionFactory;
         }
 
-        private void OnEvent(TraceEvent traceEvent)
-        {
-            traceEvent.Track(this.client);
-        }
-
         /// <summary>
         /// Gets the list of ETW Provider listening requests (information about which providers should be traced).
         /// </summary>
@@ -132,12 +127,14 @@ namespace Microsoft.ApplicationInsights.EtwCollector
                         if (this.traceEventSession != null && this.traceEventSession.Source != null && this.traceEventSession.Source.Dynamic != null)
                         {
                             this.traceEventSession.Source.Dynamic.All += this.OnEvent;
-                            Task.Factory.StartNew(() =>
-                            {
-                                this.traceEventSession.Source.Process();
-                                this.traceEventSession.Source.Dynamic.All -= this.OnEvent;
-                                this.isInitialized = false;
-                            }, TaskCreationOptions.LongRunning);
+                            Task.Factory.StartNew(
+                                () =>
+                                {
+                                    this.traceEventSession.Source.Process();
+                                    this.traceEventSession.Source.Dynamic.All -= this.OnEvent;
+                                    this.isInitialized = false;
+                                },
+                                TaskCreationOptions.LongRunning);
                         }
                     }
                     finally
@@ -240,6 +237,11 @@ namespace Microsoft.ApplicationInsights.EtwCollector
             {
                 this.traceEventSession.DisableProvider(providerName);
             }
+        }
+
+        private void OnEvent(TraceEvent traceEvent)
+        {
+            traceEvent.Track(this.client);
         }
     }
 }

--- a/src/Adapters/Etw.Net451/ITraceEventSession.cs
+++ b/src/Adapters/Etw.Net451/ITraceEventSession.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ApplicationInsights.EtwCollector
         /// to start receiving events. Currently does not work on file based sources (we
         /// expect you to wait until the file is complete).
         /// </summary>
-        ETWTraceEventSource Source { get; }
+        TraceEventDispatcher Source { get; }
 
         /// <summary>
         /// Enables a provider by its name, level and keywords.


### PR DESCRIPTION
The tests passed on the local debugging session but failed during
running. There are 2 issues contribute to the failure on the sever.

1. Initialize() will return slightly earlier than
traceEventSession.Process() is fully running. Which leads to the event
lost for the unit test because the unit test invokes the event
immediately after calling the initilize() on the module.
Although the right fix would be locking on initilize() until Process()
is fully up, it is an overhead to implement. At the same time, in real
world scenario, events are emitted in different process and will be
capatured once Process() is up.
So, I am fixing the issue by simple put a delay in the unit test after
calling initialize().

2. When using F5 (Debug) to invoke unit tests and break the test case in
the middle, the trace event session will be left. That's why after
Debug, the unit tests start to pass because there are existing opening
sessions writing the events into the channel. This introduces huge
inconsistence for the unit test result.
I added clean up logic for the tests to solve this issue.