### PR TITLE
Adding a constructor to the TraceListener which allows the user to specify a TelemetryClient

### DIFF
--- a/src/Adapters.Tests/TraceListener.Tests.Shared/ApplicationInsightsTraceListenerTests.cs
+++ b/src/Adapters.Tests/TraceListener.Tests.Shared/ApplicationInsightsTraceListenerTests.cs
@@ -26,7 +26,7 @@
         [TestCategory("TraceListener")]
         public void TraceListenerInitializeDoesNotThrowWhenInstrumentationKeyIsNull()
         {
-            var listener = new ApplicationInsightsTraceListener(null);
+            var listener = new ApplicationInsightsTraceListener(instrumentationKey: null);
             listener.Dispose();
         }
 
@@ -37,7 +37,7 @@
             var listener = new ApplicationInsightsTraceListener(string.Empty);
             listener.Dispose();
         }
-        
+
         [TestMethod]
         [TestCategory("TraceListener")]
         public void TraceListenerWriteUsedApplicationInsightsConfigInstrumentationKeyWhenUnspecifiedInstrumentationKey()
@@ -46,9 +46,25 @@
             // the Telemetry event is assigned with the InstrumentationKey from configuration
             TelemetryConfiguration.Active.TelemetryChannel = this.adapterHelper.Channel;
 
-            using (var listener = new ApplicationInsightsTraceListener(null))
-            {                
+            using (var listener = new ApplicationInsightsTraceListener(instrumentationKey: null))
+            {
                 this.VerifyMessagesInMockChannel(listener, this.adapterHelper.InstrumentationKey);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("TraceListener")]
+        public void TraceListenerWriteUsedTelemetryClientInstrumentationKeyWhenSpecified()
+        {
+            // Changing the channel to Mock channel to verify 
+            // the Telemetry event is assigned with the InstrumentationKey from configuration
+            TelemetryConfiguration.Active.TelemetryChannel = this.adapterHelper.Channel;
+
+            string instrumentationKey = Guid.NewGuid().ToString();
+            var telemetryClient = new TelemetryClient { InstrumentationKey = instrumentationKey };
+            using (var listener = new ApplicationInsightsTraceListener(telemetryClient))
+            {
+                this.VerifyMessagesInMockChannel(listener, instrumentationKey);
             }
         }
 

--- a/src/Adapters/TraceListener.Shared/ApplicationInsightsTraceListener.cs
+++ b/src/Adapters/TraceListener.Shared/ApplicationInsightsTraceListener.cs
@@ -47,6 +47,16 @@ namespace Microsoft.ApplicationInsights.TraceListener
             this.TelemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("sd:");
         }
 
+        /// <summary>
+        /// Initializes a new instance of the ApplicationInsightsTraceListener class, specifying a TelemetryClient to use
+        /// </summary>
+        /// <param name="telemetryClient">TelemetryClient to use for tracing</param>
+        public ApplicationInsightsTraceListener(TelemetryClient telemetryClient)
+        {
+            this.TelemetryClient = telemetryClient;
+            this.TelemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("sd:");
+        }
+
         internal TelemetryClient TelemetryClient { get; set; }
         
         /// <summary>


### PR DESCRIPTION
This is useful if they'd like to configure their SessionId for example. Added a new UT for the change, and verified that all tests pass