### PR TITLE
Suppress TPL events for EventSource and ETW modules

### DIFF
--- a/src/Adapters.Tests/Etw.Net451.Tests/TestProvider.cs
+++ b/src/Adapters.Tests/Etw.Net451.Tests/TestProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
             WriteEvent(TrickyEventId, EventId, EventName, Message);
         }
 
-                [Event(RequestStartEventId, Level = EventLevel.Informational, ActivityOptions = EventActivityOptions.Recursive)]
+        [Event(RequestStartEventId, Level = EventLevel.Informational, ActivityOptions = EventActivityOptions.Recursive)]
         public void RequestStart(int requestId)
         {
             WriteEvent(RequestStartEventId, requestId);

--- a/src/Adapters.Tests/Etw.Net451.Tests/TestProvider.cs
+++ b/src/Adapters.Tests/Etw.Net451.Tests/TestProvider.cs
@@ -16,6 +16,8 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
         public const int InfoEventId = 1;
         public const int WarningEventId = 2;
         public const int ComplexEventId = 4;
+        public const int RequestStartEventId = 5;
+        public const int RequestStopEventId = 6;
         public const int TrickyEventId = 7;
 
         public static readonly TestProvider Log = new TestProvider();
@@ -43,6 +45,18 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
         public void Tricky(int EventId, string EventName, string Message)
         {
             WriteEvent(TrickyEventId, EventId, EventName, Message);
+        }
+
+                [Event(RequestStartEventId, Level = EventLevel.Informational, ActivityOptions = EventActivityOptions.Recursive)]
+        public void RequestStart(int requestId)
+        {
+            WriteEvent(RequestStartEventId, requestId);
+        }
+
+        [Event(RequestStopEventId, Level = EventLevel.Informational, ActivityOptions = EventActivityOptions.Recursive)]
+        public void RequestStop(int requestId)
+        {
+            WriteEvent(RequestStopEventId, requestId);
         }
 
         public class Keywords

--- a/src/Adapters.Tests/Shared/CustomTelemetryChannel.cs
+++ b/src/Adapters.Tests/Shared/CustomTelemetryChannel.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ApplicationInsights
             // Pattern for Wait Handles from: https://msdn.microsoft.com/en-us/library/hh873178%28v=vs.110%29.aspx#WaitHandles
             var tcs = new TaskCompletionSource<bool>();
             var rwh = ThreadPool.RegisterWaitForSingleObject(
-                this.waitHandle, delegate { tcs.TrySetResult(true); }, null, -1, true);
+                this.waitHandle, delegate { tcs.TrySetResult(true); }, null, Convert.ToUInt32(timeout.TotalMilliseconds), true);
             var t = tcs.Task;
             t.ContinueWith((antecdent) => rwh.Unregister(null));
             return t;

--- a/src/Adapters.Tests/Shared/CustomTelemetryChannel.cs
+++ b/src/Adapters.Tests/Shared/CustomTelemetryChannel.cs
@@ -41,14 +41,32 @@ namespace Microsoft.ApplicationInsights
             }
         }
 
-        public Task WaitOneItemAsync(TimeSpan timeout)
+        public Task<int?> WaitForItemsCaptured(TimeSpan timeout)
         {
             // Pattern for Wait Handles from: https://msdn.microsoft.com/en-us/library/hh873178%28v=vs.110%29.aspx#WaitHandles
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<int?>();
+
             var rwh = ThreadPool.RegisterWaitForSingleObject(
-                this.waitHandle, delegate { tcs.TrySetResult(true); }, null, Convert.ToUInt32(timeout.TotalMilliseconds), true);
+                this.waitHandle, 
+                (state, timedOut) => {
+                    if (timedOut)
+                    {
+                        tcs.SetResult(null);
+                    }
+                    else
+                    {
+                        lock (this)
+                        {
+                            tcs.SetResult(this.SentItems.Length);
+                        }
+                    }
+                }, 
+                state: null, 
+                millisecondsTimeOutInterval: Convert.ToUInt32(timeout.TotalMilliseconds), 
+                executeOnlyOnce: true);
+
             var t = tcs.Task;
-            t.ContinueWith((antecdent) => rwh.Unregister(null));
+            t.ContinueWith((previousTask) => rwh.Unregister(null));
             return t;
         }
 

--- a/src/Adapters/Etw.Net451/EtwTelemetryModule.cs
+++ b/src/Adapters/Etw.Net451/EtwTelemetryModule.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ApplicationInsights.EtwCollector
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Implementation;
     using Microsoft.ApplicationInsights.TraceEvent.Shared.Implementation;
+    using Microsoft.ApplicationInsights.TraceEvent.Shared.Utilities;
     using Microsoft.Diagnostics.Tracing;
     using Microsoft.Diagnostics.Tracing.Session;
 
@@ -241,7 +242,12 @@ namespace Microsoft.ApplicationInsights.EtwCollector
 
         private void OnEvent(TraceEvent traceEvent)
         {
-            traceEvent.Track(this.client);
+            // Suppress events from TplEventSource--they are mostly interesting for debugging task processing and interaction,
+            // and not that useful for production tracing. However, TPL EventSource must be enabled to get hierarchical activity IDs.
+            if (!TplActivities.TplEventSourceGuid.Equals(traceEvent.ProviderGuid))
+            {
+                traceEvent.Track(this.client);
+            }
         }
     }
 }

--- a/src/Adapters/Etw.Net451/EtwTelemetryModule.cs
+++ b/src/Adapters/Etw.Net451/EtwTelemetryModule.cs
@@ -174,6 +174,15 @@ namespace Microsoft.ApplicationInsights.EtwCollector
 
         private void EnableProviders()
         {
+            // Enable TPL provider to get hierarchical activity IDs
+            var tplProviderRequest = new EtwListeningRequest()
+            {
+                ProviderGuid = TplActivities.TplEventSourceGuid,
+                Level = TraceEventLevel.Always,
+                Keywords = TplActivities.TaskFlowActivityIdsKeyword
+            };
+            this.EnableProvider(tplProviderRequest);
+
             foreach (EtwListeningRequest request in this.Sources)
             {
                 this.EnableProvider(request);

--- a/src/Adapters/EventSource.Shared/EventSource.Shared/EventSource.Shared.projitems
+++ b/src/Adapters/EventSource.Shared/EventSource.Shared/EventSource.Shared.projitems
@@ -12,5 +12,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\EventSourceListenerEventSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ActivityPathDecoder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\StringBuilderCache.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\TplActivities.cs" />
   </ItemGroup>
 </Project>

--- a/src/Adapters/EventSource.Shared/EventSource.Shared/Utilities/TplActivities.cs
+++ b/src/Adapters/EventSource.Shared/EventSource.Shared/Utilities/TplActivities.cs
@@ -1,0 +1,26 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TplActivities.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.ApplicationInsights.TraceEvent.Shared.Utilities
+{
+    /// <summary>
+    /// Provides well-known values for working with Task Parallel Library (TPL) EventSource.
+    /// </summary>
+    public static class TplActivities
+    {
+        /// <summary>
+        /// Gets the GUID of the TPL EventSource.
+        /// </summary>
+        public static readonly Guid TplEventSourceGuid = new Guid("2e5dba47-a3d2-4d16-8ee0-6671ffdcd7b5");
+
+        /// <summary>
+        /// Gets the keyword that enables hierarchical activity IDs.
+        /// </summary>
+        public static readonly ulong TaskFlowActivityIdsKeyword = 0x80;
+    }
+}


### PR DESCRIPTION
The problem was found by EventFlow users, this change is a port of the fix from that library.

Basically, we want the TPL EventSource to be enabled as it provides hierarchical activity IDs. But the events emitted from that EventSource are not very useful, at least not during production tracing, so we want them disabled. Examples of events emitted by this source are "task X started task Y", "task X resumed after waiting on tasks Y and Z" and similar.

We could consider disabling the events only if they are not explicitly requested by the telemetry module configuration, but I doubt users will be interested in TPL events in the APM context.