### PR TITLE
Correct reference to base sdk, update version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog 
 
+### Version 2.4.0-beta1/2
+Update Application Insights API reference to [2.4.0-beta3]
+Added support for logs from EventSource, ETW and Diagnostic Source.
+
 ### Version 2.1.1
 
 - Update NLog reference to [4.3.8](https://github.com/NLog/NLog/releases/tag/4.3.8)

--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -8,7 +8,7 @@
     <SemanticVersionMajor>2</SemanticVersionMajor>
     <SemanticVersionMinor>4</SemanticVersionMinor>
     <SemanticVersionPatch>0</SemanticVersionPatch>
-    <PreReleaseMilestone>beta1</PreReleaseMilestone>
+    <PreReleaseMilestone>beta2</PreReleaseMilestone>
     <!-- 
       Date when Semantic Version was changed. 
       Update for every public release.

--- a/src/Adapters.Tests/DiagnosticSource.Tests/DiagnosticSource.Tests.csproj
+++ b/src/Adapters.Tests/DiagnosticSource.Tests/DiagnosticSource.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.13" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.13" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.3.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0-beta3" />
     <PackageReference Include="Microbuild.Core" Version="0.2.0" />
   </ItemGroup>
 

--- a/src/Adapters.Tests/Etw.Net451.Tests/Etw.Net451.Tests.csproj
+++ b/src/Adapters.Tests/Etw.Net451.Tests/Etw.Net451.Tests.csproj
@@ -22,15 +22,17 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
       <HintPath>..\..\..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.41\lib\net40\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Security" />

--- a/src/Adapters.Tests/Etw.Net451.Tests/packages.config
+++ b/src/Adapters.Tests/Etw.Net451.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net46" />
   <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="1.0.41" targetFramework="net46" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net46" />
 </packages>

--- a/src/Adapters.Tests/EventSource.Netstandard13.Tests/EventSource.Netstandard13.Tests.csproj
+++ b/src/Adapters.Tests/EventSource.Netstandard13.Tests/EventSource.Netstandard13.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.13" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.13" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0-beta1-build06467" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0-beta3" />
     <PackageReference Include="Microbuild.Core" Version="0.2.0" />
   </ItemGroup>
 

--- a/src/Adapters.Tests/Log4NetAppender.Net40.Tests/Log4NetAppender.Net40.Tests.csproj
+++ b/src/Adapters.Tests/Log4NetAppender.Net40.Tests/Log4NetAppender.Net40.Tests.csproj
@@ -24,9 +24,8 @@
       <HintPath>..\..\..\..\packages\log4net.2.0.5\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Adapters.Tests/Log4NetAppender.Net40.Tests/packages.config
+++ b/src/Adapters.Tests/Log4NetAppender.Net40.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.5" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/src/Adapters.Tests/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
+++ b/src/Adapters.Tests/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
@@ -24,12 +24,14 @@
       <HintPath>..\..\..\..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>

--- a/src/Adapters.Tests/Log4NetAppender.Net45.Tests/packages.config
+++ b/src/Adapters.Tests/Log4NetAppender.Net45.Tests/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.5" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
 </packages>

--- a/src/Adapters.Tests/NLogTarget.Net40.Tests/NLogTarget.Net40.Tests.csproj
+++ b/src/Adapters.Tests/NLogTarget.Net40.Tests/NLogTarget.Net40.Tests.csproj
@@ -19,9 +19,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Adapters.Tests/NLogTarget.Net40.Tests/packages.config
+++ b/src/Adapters.Tests/NLogTarget.Net40.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/src/Adapters.Tests/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
+++ b/src/Adapters.Tests/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
@@ -19,9 +19,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
@@ -30,6 +29,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
@@ -59,7 +61,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="..\Shared\Adapters.Shared.Tests.projitems" Label="Shared" Condition="Exists('..\Shared\Adapters.Shared.Tests.projitems')" />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />

--- a/src/Adapters.Tests/NLogTarget.Net45.Tests/packages.config
+++ b/src/Adapters.Tests/NLogTarget.Net45.Tests/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="NLog" version="4.3.11" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
 </packages>

--- a/src/Adapters.Tests/TraceListener.Net40.Tests/TraceListener.Net40.Tests.csproj
+++ b/src/Adapters.Tests/TraceListener.Net40.Tests/TraceListener.Net40.Tests.csproj
@@ -19,9 +19,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Adapters.Tests/TraceListener.Net40.Tests/packages.config
+++ b/src/Adapters.Tests/TraceListener.Net40.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/src/Adapters.Tests/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
+++ b/src/Adapters.Tests/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
@@ -19,12 +19,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
@@ -55,7 +57,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="..\Shared\Adapters.Shared.Tests.projitems" Label="Shared" Condition="Exists('..\Shared\Adapters.Shared.Tests.projitems')" />
   <Import Project="..\TraceListener.Net40.Tests.Shared\TraceListener.Net40.Tests.Shared.projitems" Label="Shared" Condition="Exists('..\TraceListener.Net40.Tests.Shared\TraceListener.Net40.Tests.Shared.projitems')" />

--- a/src/Adapters.Tests/TraceListener.Net45.Tests/packages.config
+++ b/src/Adapters.Tests/TraceListener.Net45.Tests/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
 </packages>

--- a/src/Adapters/DiagnosticSource/DiagnosticSource.csproj
+++ b/src/Adapters/DiagnosticSource/DiagnosticSource.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.3.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0-beta3" />
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0" />
     <PackageReference Include="Microbuild.Core" Version="0.2.0" />
     <PackageReference Include="StyleCop.MSBuild" Version="4.7.55" />

--- a/src/Adapters/Etw.Net451/Etw.Net451.csproj
+++ b/src/Adapters/Etw.Net451/Etw.Net451.csproj
@@ -24,9 +24,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
       <HintPath>..\..\..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.41\lib\net40\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>
@@ -34,6 +33,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EtwTelemetryModule.cs" />

--- a/src/Adapters/Etw.Net451/packages.config
+++ b/src/Adapters/Etw.Net451/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net451" />
   <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="1.0.41" targetFramework="net451" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net451" />
 </packages>

--- a/src/Adapters/EventSource.Netstandard13/EventSource.Netstandard13.csproj
+++ b/src/Adapters/EventSource.Netstandard13/EventSource.Netstandard13.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0-beta1-build06467" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0-beta3" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0" /> 
     <PackageReference Include="Microbuild.Core" Version="0.2.0" />

--- a/src/Adapters/Log4NetAppender.Net40/Log4NetAppender.Net40.csproj
+++ b/src/Adapters/Log4NetAppender.Net40/Log4NetAppender.Net40.csproj
@@ -29,9 +29,8 @@
       <HintPath>..\..\..\..\packages\log4net.2.0.5\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Adapters/Log4NetAppender.Net40/packages.config
+++ b/src/Adapters/Log4NetAppender.Net40/packages.config
@@ -3,7 +3,7 @@
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net40" />
   <package id="log4net" version="2.0.5" targetFramework="net40" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/src/Adapters/Log4NetAppender.Net45/Log4NetAppender.Net45.csproj
+++ b/src/Adapters/Log4NetAppender.Net45/Log4NetAppender.Net45.csproj
@@ -29,12 +29,14 @@
       <HintPath>..\..\..\..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Adapters/Log4NetAppender.Net45/packages.config
+++ b/src/Adapters/Log4NetAppender.Net45/packages.config
@@ -3,6 +3,7 @@
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
 </packages>

--- a/src/Adapters/NLogTarget.Net40/NLogTarget.Net40.csproj
+++ b/src/Adapters/NLogTarget.Net40/NLogTarget.Net40.csproj
@@ -24,9 +24,8 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Adapters/NLogTarget.Net40/packages.config
+++ b/src/Adapters/NLogTarget.Net40/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net40" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/src/Adapters/NLogTarget.Net45/NLogTarget.Net45.csproj
+++ b/src/Adapters/NLogTarget.Net45/NLogTarget.Net45.csproj
@@ -23,9 +23,8 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\NLog.4.3.11\lib\net45\NLog.dll</HintPath>
@@ -33,6 +32,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Adapters/NLogTarget.Net45/packages.config
+++ b/src/Adapters/NLogTarget.Net45/packages.config
@@ -2,7 +2,8 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="NLog" version="4.3.11" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
 </packages>

--- a/src/Adapters/TraceListener.Net40/TraceListener.Net40.csproj
+++ b/src/Adapters/TraceListener.Net40/TraceListener.Net40.csproj
@@ -24,9 +24,8 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Adapters/TraceListener.Net40/packages.config
+++ b/src/Adapters/TraceListener.Net40/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net40" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/src/Adapters/TraceListener.Net45/TraceListener.Net45.csproj
+++ b/src/Adapters/TraceListener.Net45/TraceListener.Net45.csproj
@@ -23,12 +23,14 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Adapters/TraceListener.Net45/packages.config
+++ b/src/Adapters/TraceListener.Net45/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
 </packages>

--- a/src/NuGet.Tests/Xdt.Tests/Xdt.Tests.csproj
+++ b/src/NuGet.Tests/Xdt.Tests/Xdt.Tests.csproj
@@ -24,14 +24,16 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
@@ -79,7 +81,9 @@
     <EmbeddedResource Include="..\..\NuGet\EtwCollector\ApplicationInsights.config.uninstall.xdt">
       <Link>Resources\EtwCollector\ApplicationInsights.config.uninstall.xdt</Link>
     </EmbeddedResource>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Log4Net\TestDataSet.xml" />

--- a/src/NuGet.Tests/Xdt.Tests/packages.config
+++ b/src/NuGet.Tests/Xdt.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Updated all projects to refer to 2.4.0-beta3 of base sdk
Renamed version to 2.4.0-beta2.
The previous release did not correctly refer to base sdk verisons.