### PR TITLE
Override FlushAsync in NLogTarget to flush contained TelemetryClient

### DIFF
--- a/src/Adapters.Tests/NLogTarget.Tests.Shared/NLogTargetTests.cs
+++ b/src/Adapters.Tests/NLogTarget.Tests.Shared/NLogTargetTests.cs
@@ -369,6 +369,19 @@
             Assert.AreEqual(loggerNameVal2, traceTelemetry.Properties["LoggerName_1"]);
         }
 
+        [TestMethod]
+        [TestCategory("NLogTarget")]
+        public void TargetFlushesTelemetryClient()
+        {
+            var aiLogger = this.CreateTargetWithGivenInstrumentationKey();
+            var before = this.adapterHelper.Channel.FlushCount;
+
+            aiLogger.Factory.Flush();
+            var after = this.adapterHelper.Channel.FlushCount;
+
+            Assert.IsTrue(after - before == 1);
+        }
+
         private void VerifyMessagesInMockChannel(Logger aiLogger, string instrumentationKey)
         {
             aiLogger.Trace("Sample trace message");

--- a/src/Adapters.Tests/Shared/CustomTelemetryChannel.cs
+++ b/src/Adapters.Tests/Shared/CustomTelemetryChannel.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ApplicationInsights
     using Microsoft.ApplicationInsights.DataContracts;
     internal class CustomTelemetryChannel : ITelemetryChannel
     {
+        private int flushCount = 0;
         private EventWaitHandle waitHandle;
 
         public CustomTelemetryChannel()
@@ -26,6 +27,11 @@ namespace Microsoft.ApplicationInsights
         public bool? DeveloperMode { get; set; }
 
         public string EndpointAddress { get; set; }
+
+        public int FlushCount
+        {
+            get { return flushCount; }
+        }
 
         public ITelemetry[] SentItems { get; private set; }
 
@@ -72,7 +78,10 @@ namespace Microsoft.ApplicationInsights
 
         public void Flush()
         {
-            throw new System.NotImplementedException();
+            lock (this)
+            {
+                ++flushCount;
+            }
         }
 
         public void Dispose()
@@ -84,6 +93,7 @@ namespace Microsoft.ApplicationInsights
             lock (this)
             {
                 this.SentItems = new ITelemetry[0];
+                this.flushCount = 0;
             }
 
             return this;

--- a/src/Adapters/NLogTarget.Shared/ApplicationInsightsTarget.cs
+++ b/src/Adapters/NLogTarget.Shared/ApplicationInsightsTarget.cs
@@ -17,6 +17,7 @@ namespace Microsoft.ApplicationInsights.NLogTarget
     using Microsoft.ApplicationInsights.Implementation;
 
     using NLog;
+    using NLog.Common;
     using NLog.Targets;
       
     /// <summary>
@@ -47,6 +48,16 @@ namespace Microsoft.ApplicationInsights.NLogTarget
         internal TelemetryClient TelemetryClient
         {
             get { return this.telemetryClient; }
+        }
+
+        /// <summary>
+        /// Flush any pending log messages asynchronously (in case of asynchronous targets).
+        /// </summary>
+        /// <param name="asyncContinuation">The asynchronous continuation.</param>
+        protected override void FlushAsync(AsyncContinuation asyncContinuation)
+        {
+            this.telemetryClient.Flush();
+            base.FlushAsync(asyncContinuation);
         }
 
         /// <summary>


### PR DESCRIPTION
# Overview
This PR implements the `FlushAsync` method in `ApplicationInsightsTarget` to utilize the preferred NLog mechanism to flush the contained `TelemetryClient`.

## Adapter Changes
- Implement `ApplicationInsightsTarget.FlushAsync` by flushing `TelemetryClient` and calling base class 'FlushAsync'

## Unit Test Changes
- Implement `Flush` method in `CustomTelemetryChannel`
- Expose `FlushCount` property on `CustomTelemetryChannel`
- Initialize and cleanup `FlushCount` as appropriate
- Create `TargetFlushesTelemetryClient` unit test to verify proper execution of `ApplicationInsightsTarget.FlushAsync`
