### PR TITLE
2.4.0 stable release.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,7 +69,7 @@
         <PackagesDir>$(EnlistmentRoot)\..\packages</PackagesDir>
         <PackagesDir>$([System.IO.Path]::GetFullPath( $(PackagesDir) ))</PackagesDir>
         
-        <CoreSdkVersion>2.4.0-beta3</CoreSdkVersion>                
+        <CoreSdkVersion>2.4.0</CoreSdkVersion>                
     </PropertyGroup>
    
     <PropertyGroup>

--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -6,14 +6,14 @@
       Update for every public release. 
     -->
     <SemanticVersionMajor>2</SemanticVersionMajor>
-    <SemanticVersionMinor>3</SemanticVersionMinor>
+    <SemanticVersionMinor>4</SemanticVersionMinor>
     <SemanticVersionPatch>0</SemanticVersionPatch>
     <PreReleaseMilestone></PreReleaseMilestone>
     <!-- 
       Date when Semantic Version was changed. 
       Update for every public release.
     -->
-    <SemanticVersionDate>2017-04-07</SemanticVersionDate>
+    <SemanticVersionDate>2017-05-07</SemanticVersionDate>
     
     <PreReleaseVersionFileName>.PreReleaseVersion</PreReleaseVersionFileName>
     <PreReleaseVersionFilePath>$(MSBuildThisFileDirectory)$(PreReleaseVersionFileName)</PreReleaseVersionFilePath>

--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -13,7 +13,7 @@
       Date when Semantic Version was changed. 
       Update for every public release.
     -->
-    <SemanticVersionDate>2017-08-04</SemanticVersionDate>
+    <SemanticVersionDate>2017-05-07</SemanticVersionDate>
     
     <PreReleaseVersionFileName>.PreReleaseVersion</PreReleaseVersionFileName>
     <PreReleaseVersionFilePath>$(MSBuildThisFileDirectory)$(PreReleaseVersionFileName)</PreReleaseVersionFilePath>

--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -8,12 +8,12 @@
     <SemanticVersionMajor>2</SemanticVersionMajor>
     <SemanticVersionMinor>4</SemanticVersionMinor>
     <SemanticVersionPatch>0</SemanticVersionPatch>
-    <PreReleaseMilestone>beta2</PreReleaseMilestone>
+    <PreReleaseMilestone></PreReleaseMilestone>
     <!-- 
       Date when Semantic Version was changed. 
       Update for every public release.
     -->
-    <SemanticVersionDate>2017-05-07</SemanticVersionDate>
+    <SemanticVersionDate>2017-08-04</SemanticVersionDate>
     
     <PreReleaseVersionFileName>.PreReleaseVersion</PreReleaseVersionFileName>
     <PreReleaseVersionFilePath>$(MSBuildThisFileDirectory)$(PreReleaseVersionFileName)</PreReleaseVersionFilePath>

--- a/Logging.sln
+++ b/Logging.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Adapters", "Adapters", "{EE933574-C82B-4E59-A0D1-05328197B937}"
 EndProject
@@ -41,7 +41,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TraceListener.NuGet", "src\
 		{E3766DD1-F376-43F8-B242-6CF06E186179} = {E3766DD1-F376-43F8-B242-6CF06E186179}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventSourceListener.NuGet", "src\NuGet\EventSourceListener\EventSourceListener.NuGet.csproj", "{2881A618-8101-4C67-8CAC-1C776B23789E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventSourceListener.NuGet", "src\NuGet\EventSourceListener\EventSourceListener.NuGet.csproj", "{2881A618-8101-4C67-8CAC-1C776B23789E}"
 	ProjectSection(ProjectDependencies) = postProject
 		{A539BB1D-29FF-48E8-8D6E-DFCC543DC2B4} = {A539BB1D-29FF-48E8-8D6E-DFCC543DC2B4}
 	EndProjectSection
@@ -91,7 +91,7 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "CommonShared", "src\Adapter
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "CommonTestShared", "src\Adapters.Tests\CommonTestShared\CommonTestShared.shproj", "{3B9AB7FA-562D-4E4E-86E3-3348426BC0D9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventSource.Netstandard13.Tests", "src\Adapters.Tests\EventSource.Netstandard13.Tests\EventSource.Netstandard13.Tests.csproj", "{7030CAC6-4B94-4735-B146-C0FC3097ACA6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventSource.Netstandard13.Tests", "src\Adapters.Tests\EventSource.Netstandard13.Tests\EventSource.Netstandard13.Tests.csproj", "{7030CAC6-4B94-4735-B146-C0FC3097ACA6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Etw.Net451", "src\Adapters\Etw.Net451\Etw.Net451.csproj", "{9BECFB0F-4F6D-4A84-931F-70DA3E4E2813}"
 EndProject
@@ -103,14 +103,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EtwCollector.NuGet", "src\N
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventSource.Netstandard13", "src\Adapters\EventSource.Netstandard13\EventSource.Netstandard13.csproj", "{A539BB1D-29FF-48E8-8D6E-DFCC543DC2B4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiagnosticSource", "src\Adapters\DiagnosticSource\DiagnosticSource.csproj", "{57F41D53-A8D1-42D6-AFBE-406436CFA7DF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiagnosticSource", "src\Adapters\DiagnosticSource\DiagnosticSource.csproj", "{57F41D53-A8D1-42D6-AFBE-406436CFA7DF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiagnosticSourceListener.NuGet", "src\NuGet\DiagnosticSourceListener\DiagnosticSourceListener.NuGet.csproj", "{9748B531-F7A8-4F35-8C8A-2B2916C5582E}"
 	ProjectSection(ProjectDependencies) = postProject
 		{57F41D53-A8D1-42D6-AFBE-406436CFA7DF} = {57F41D53-A8D1-42D6-AFBE-406436CFA7DF}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiagnosticSource.Tests", "src\Adapters.Tests\DiagnosticSource.Tests\DiagnosticSource.Tests.csproj", "{A716D37C-B736-4CF0-8DF5-36BDE57DA2A5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiagnosticSource.Tests", "src\Adapters.Tests\DiagnosticSource.Tests\DiagnosticSource.Tests.csproj", "{A716D37C-B736-4CF0-8DF5-36BDE57DA2A5}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -236,10 +236,6 @@ Global
 		{E6F03762-6BD6-4B38-8798-42C189AAB18C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{E6F03762-6BD6-4B38-8798-42C189AAB18C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{E6F03762-6BD6-4B38-8798-42C189AAB18C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{A539BB1D-29FF-48E8-8D6E-DFCC543DC2B4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{A539BB1D-29FF-48E8-8D6E-DFCC543DC2B4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{A539BB1D-29FF-48E8-8D6E-DFCC543DC2B4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{A539BB1D-29FF-48E8-8D6E-DFCC543DC2B4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{7030CAC6-4B94-4735-B146-C0FC3097ACA6}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{7030CAC6-4B94-4735-B146-C0FC3097ACA6}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{7030CAC6-4B94-4735-B146-C0FC3097ACA6}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -256,6 +252,10 @@ Global
 		{F371663D-99DB-4722-BC38-55EC178A84EB}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{F371663D-99DB-4722-BC38-55EC178A84EB}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{F371663D-99DB-4722-BC38-55EC178A84EB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{A539BB1D-29FF-48E8-8D6E-DFCC543DC2B4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{A539BB1D-29FF-48E8-8D6E-DFCC543DC2B4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{A539BB1D-29FF-48E8-8D6E-DFCC543DC2B4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{A539BB1D-29FF-48E8-8D6E-DFCC543DC2B4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{57F41D53-A8D1-42D6-AFBE-406436CFA7DF}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{57F41D53-A8D1-42D6-AFBE-406436CFA7DF}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{57F41D53-A8D1-42D6-AFBE-406436CFA7DF}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU

--- a/src/Adapters.Tests/DiagnosticSource.Tests/DiagnosticSource.Tests.csproj
+++ b/src/Adapters.Tests/DiagnosticSource.Tests/DiagnosticSource.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.13" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.13" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.3" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
     <PackageReference Include="Microbuild.Core" Version="0.2.0" />
   </ItemGroup>
 

--- a/src/Adapters.Tests/Etw.Net451.Tests/Etw.Net451.Tests.csproj
+++ b/src/Adapters.Tests/Etw.Net451.Tests/Etw.Net451.Tests.csproj
@@ -31,7 +31,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />

--- a/src/Adapters.Tests/Etw.Net451.Tests/Etw.Net451.Tests.csproj
+++ b/src/Adapters.Tests/Etw.Net451.Tests/Etw.Net451.Tests.csproj
@@ -23,7 +23,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
       <HintPath>..\..\..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.41\lib\net40\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>

--- a/src/Adapters.Tests/Etw.Net451.Tests/packages.config
+++ b/src/Adapters.Tests/Etw.Net451.Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net46" />
   <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="1.0.41" targetFramework="net46" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net46" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net46" />
 </packages>

--- a/src/Adapters.Tests/Etw.Net451.Tests/packages.config
+++ b/src/Adapters.Tests/Etw.Net451.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net46" />
   <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="1.0.41" targetFramework="net46" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net46" />
 </packages>

--- a/src/Adapters.Tests/EventSource.Netstandard13.Tests/EventSource.Netstandard13.Tests.csproj
+++ b/src/Adapters.Tests/EventSource.Netstandard13.Tests/EventSource.Netstandard13.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.13" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.13" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0-beta3" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
     <PackageReference Include="Microbuild.Core" Version="0.2.0" />
   </ItemGroup>
 

--- a/src/Adapters.Tests/Log4NetAppender.Net40.Tests/Log4NetAppender.Net40.Tests.csproj
+++ b/src/Adapters.Tests/Log4NetAppender.Net40.Tests/Log4NetAppender.Net40.Tests.csproj
@@ -25,7 +25,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Adapters.Tests/Log4NetAppender.Net40.Tests/packages.config
+++ b/src/Adapters.Tests/Log4NetAppender.Net40.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.5" targetFramework="net40" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/src/Adapters.Tests/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
+++ b/src/Adapters.Tests/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
@@ -25,7 +25,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Adapters.Tests/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
+++ b/src/Adapters.Tests/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
@@ -30,7 +30,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Adapters.Tests/Log4NetAppender.Net45.Tests/packages.config
+++ b/src/Adapters.Tests/Log4NetAppender.Net45.Tests/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/src/Adapters.Tests/Log4NetAppender.Net45.Tests/packages.config
+++ b/src/Adapters.Tests/Log4NetAppender.Net45.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.5" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />

--- a/src/Adapters.Tests/NLogTarget.Net40.Tests/NLogTarget.Net40.Tests.csproj
+++ b/src/Adapters.Tests/NLogTarget.Net40.Tests/NLogTarget.Net40.Tests.csproj
@@ -20,7 +20,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Adapters.Tests/NLogTarget.Net40.Tests/packages.config
+++ b/src/Adapters.Tests/NLogTarget.Net40.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/src/Adapters.Tests/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
+++ b/src/Adapters.Tests/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
@@ -30,7 +30,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Adapters.Tests/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
+++ b/src/Adapters.Tests/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
@@ -20,7 +20,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">

--- a/src/Adapters.Tests/NLogTarget.Net45.Tests/packages.config
+++ b/src/Adapters.Tests/NLogTarget.Net45.Tests/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="NLog" version="4.3.11" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/src/Adapters.Tests/NLogTarget.Net45.Tests/packages.config
+++ b/src/Adapters.Tests/NLogTarget.Net45.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />

--- a/src/Adapters.Tests/TraceListener.Net40.Tests/TraceListener.Net40.Tests.csproj
+++ b/src/Adapters.Tests/TraceListener.Net40.Tests/TraceListener.Net40.Tests.csproj
@@ -20,7 +20,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Adapters.Tests/TraceListener.Net40.Tests/packages.config
+++ b/src/Adapters.Tests/TraceListener.Net40.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/src/Adapters.Tests/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
+++ b/src/Adapters.Tests/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
@@ -25,7 +25,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Adapters.Tests/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
+++ b/src/Adapters.Tests/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
@@ -20,7 +20,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Adapters.Tests/TraceListener.Net45.Tests/packages.config
+++ b/src/Adapters.Tests/TraceListener.Net45.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />

--- a/src/Adapters.Tests/TraceListener.Net45.Tests/packages.config
+++ b/src/Adapters.Tests/TraceListener.Net45.Tests/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/src/Adapters/DiagnosticSource/DiagnosticSource.csproj
+++ b/src/Adapters/DiagnosticSource/DiagnosticSource.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.3" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0" />
     <PackageReference Include="Microbuild.Core" Version="0.2.0" />
     <PackageReference Include="StyleCop.MSBuild" Version="4.7.55" />

--- a/src/Adapters/DiagnosticSource/DiagnosticSource.csproj
+++ b/src/Adapters/DiagnosticSource/DiagnosticSource.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0" />
     <PackageReference Include="Microbuild.Core" Version="0.2.0" />
     <PackageReference Include="StyleCop.MSBuild" Version="4.7.55" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0" />
   </ItemGroup>
 
   <Import Project="..\CommonShared\CommonShared.projitems" Label="Shared" />

--- a/src/Adapters/Etw.Net451/Etw.Net451.csproj
+++ b/src/Adapters/Etw.Net451/Etw.Net451.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
       <HintPath>..\..\..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.41\lib\net40\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>

--- a/src/Adapters/Etw.Net451/Etw.Net451.csproj
+++ b/src/Adapters/Etw.Net451/Etw.Net451.csproj
@@ -34,7 +34,7 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Adapters/Etw.Net451/packages.config
+++ b/src/Adapters/Etw.Net451/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net451" />
   <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="1.0.41" targetFramework="net451" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net451" />
 </packages>

--- a/src/Adapters/Etw.Net451/packages.config
+++ b/src/Adapters/Etw.Net451/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net451" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net451" />
   <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="1.0.41" targetFramework="net451" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net451" />

--- a/src/Adapters/EventSource.Netstandard13/EventSource.Netstandard13.csproj
+++ b/src/Adapters/EventSource.Netstandard13/EventSource.Netstandard13.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0-beta3" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0" /> 
     <PackageReference Include="Microbuild.Core" Version="0.2.0" />

--- a/src/Adapters/Log4NetAppender.Net40/Log4NetAppender.Net40.csproj
+++ b/src/Adapters/Log4NetAppender.Net40/Log4NetAppender.Net40.csproj
@@ -30,7 +30,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Adapters/Log4NetAppender.Net40/packages.config
+++ b/src/Adapters/Log4NetAppender.Net40/packages.config
@@ -3,7 +3,7 @@
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net40" />
   <package id="log4net" version="2.0.5" targetFramework="net40" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/src/Adapters/Log4NetAppender.Net45/Log4NetAppender.Net45.csproj
+++ b/src/Adapters/Log4NetAppender.Net45/Log4NetAppender.Net45.csproj
@@ -30,7 +30,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Adapters/Log4NetAppender.Net45/Log4NetAppender.Net45.csproj
+++ b/src/Adapters/Log4NetAppender.Net45/Log4NetAppender.Net45.csproj
@@ -35,7 +35,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Adapters/Log4NetAppender.Net45/packages.config
+++ b/src/Adapters/Log4NetAppender.Net45/packages.config
@@ -3,7 +3,7 @@
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/src/Adapters/Log4NetAppender.Net45/packages.config
+++ b/src/Adapters/Log4NetAppender.Net45/packages.config
@@ -5,5 +5,5 @@
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/src/Adapters/NLogTarget.Net40/NLogTarget.Net40.csproj
+++ b/src/Adapters/NLogTarget.Net40/NLogTarget.Net40.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Adapters/NLogTarget.Net40/packages.config
+++ b/src/Adapters/NLogTarget.Net40/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net40" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/src/Adapters/NLogTarget.Net45/NLogTarget.Net45.csproj
+++ b/src/Adapters/NLogTarget.Net45/NLogTarget.Net45.csproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\NLog.4.3.11\lib\net45\NLog.dll</HintPath>

--- a/src/Adapters/NLogTarget.Net45/NLogTarget.Net45.csproj
+++ b/src/Adapters/NLogTarget.Net45/NLogTarget.Net45.csproj
@@ -33,7 +33,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Adapters/NLogTarget.Net45/packages.config
+++ b/src/Adapters/NLogTarget.Net45/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="NLog" version="4.3.11" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/src/Adapters/NLogTarget.Net45/packages.config
+++ b/src/Adapters/NLogTarget.Net45/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net45" />
   <package id="NLog" version="4.3.11" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />

--- a/src/Adapters/TraceListener.Net40/TraceListener.Net40.csproj
+++ b/src/Adapters/TraceListener.Net40/TraceListener.Net40.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Adapters/TraceListener.Net40/packages.config
+++ b/src/Adapters/TraceListener.Net40/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net40" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net40" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/src/Adapters/TraceListener.Net45/TraceListener.Net45.csproj
+++ b/src/Adapters/TraceListener.Net45/TraceListener.Net45.csproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Adapters/TraceListener.Net45/TraceListener.Net45.csproj
+++ b/src/Adapters/TraceListener.Net45/TraceListener.Net45.csproj
@@ -29,7 +29,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Adapters/TraceListener.Net45/packages.config
+++ b/src/Adapters/TraceListener.Net45/packages.config
@@ -4,5 +4,5 @@
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/src/Adapters/TraceListener.Net45/packages.config
+++ b/src/Adapters/TraceListener.Net45/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/src/NuGet.Tests/Xdt.Tests/Xdt.Tests.csproj
+++ b/src/NuGet.Tests/Xdt.Tests/Xdt.Tests.csproj
@@ -32,7 +32,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0-beta-25130-03\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/src/NuGet.Tests/Xdt.Tests/Xdt.Tests.csproj
+++ b/src/NuGet.Tests/Xdt.Tests/Xdt.Tests.csproj
@@ -25,7 +25,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0-beta3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>

--- a/src/NuGet.Tests/Xdt.Tests/packages.config
+++ b/src/NuGet.Tests/Xdt.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />

--- a/src/NuGet.Tests/Xdt.Tests/packages.config
+++ b/src/NuGet.Tests/Xdt.Tests/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.ApplicationInsights" version="2.4.0-beta3" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-beta-25130-03" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/src/NuGet/DiagnosticSourceListener/Package.nuspec
+++ b/src/NuGet/DiagnosticSourceListener/Package.nuspec
@@ -17,12 +17,12 @@
     <tags>Analytics ApplicationInsights Telemetry ASP.NET ASMX Web Azure Server Services ASPX Websites Role Logging Log Tracing DiagnosticSource DiagnosticSourceListener</tags>
     <dependencies>
       <group targetFramework="net45">
-        <dependency id="Microsoft.ApplicationInsights" version="2.3" />
-        <dependency id="System.Diagnostics.DiagnosticSource" version="4.3.0" />
+        <dependency id="Microsoft.ApplicationInsights" version="$coresdkversion$" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0" />
       </group>
       <group targetFramework="netstandard13">
-        <dependency id="Microsoft.ApplicationInsights" version="2.3" />
-        <dependency id="System.Diagnostics.DiagnosticSource" version="4.3.0" />
+        <dependency id="Microsoft.ApplicationInsights" version="$coresdkversion$" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Updated diagnostic source to 4.4.0
Base SDK to 2.4.0

DiagnosticSource adapter is still on 4.3 and 2.3 of diagsource and base sdk respectively. @pharring , @SergeyKanzhelev should i update diagsource adapter as well for this stable release?