### PR TITLE
Fix deadlock in EventSourceTelemetryModule

### DIFF
--- a/src/Adapters.Tests/EventSource.Netstandard13.Tests/EventSourceTelemetryModuleTests.cs
+++ b/src/Adapters.Tests/EventSource.Netstandard13.Tests/EventSourceTelemetryModuleTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Tests
 
                 TestEventSource.Default.InfoEvent("Hey!");
 
-                TraceTelemetry telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.First();
+                TraceTelemetry telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.Single();
                 Assert.AreEqual("Hey!", telemetry.Message);
                 Assert.AreEqual("Hey!", telemetry.Properties["information"]);
                 Assert.AreEqual(SeverityLevel.Information, telemetry.SeverityLevel);
@@ -99,7 +99,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Tests
                 {
                     eventSource.Message("Hey!");
 
-                    TraceTelemetry telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.First();
+                    TraceTelemetry telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.Single();
                     Assert.AreEqual("Hey!", telemetry.Message);
                     Assert.AreEqual("Hey!", telemetry.Properties["message"]);
                     Assert.AreEqual(SeverityLevel.Information, telemetry.SeverityLevel);

--- a/src/Adapters.Tests/EventSource.Netstandard13.Tests/OtherTestEventSource.cs
+++ b/src/Adapters.Tests/EventSource.Netstandard13.Tests/OtherTestEventSource.cs
@@ -1,0 +1,22 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="OtherTestEventSource.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Microsoft.ApplicationInsights.EventSourceListener.Tests
+{
+    using System.Diagnostics.Tracing;
+
+    [EventSource(Name = OtherTestEventSource.ProviderName)]
+    internal class OtherTestEventSource : EventSource
+    {
+        public const string ProviderName = "Microsoft-ApplicationInsights-Extensibility-EventSourceListener-Tests-Other";
+
+        [Event(3, Level = EventLevel.Informational, Message = "{0}")]
+        public void Message(string message)
+        {
+            WriteEvent(3, message);
+        }
+    }
+}

--- a/src/Adapters/EventSource.Netstandard13/EventSourceTelemetryModule.cs
+++ b/src/Adapters/EventSource.Netstandard13/EventSourceTelemetryModule.cs
@@ -74,6 +74,12 @@ namespace Microsoft.ApplicationInsights.EventSourceListener
                     }
                 }
 
+                // Set the initialized flag now to ensure that we do not miss any sources that came online as we are executing the initialization
+                // (OnEventSourceCreated() might have been called on a separate thread). Worst case we will attempt to enable the same source twice
+                // (with same settings), but that is OK, as the semantics of EnableEvents() is really "update what is being tracked", so it is fine
+                // to call it multiple times for the same source.
+                this.initialized = true;
+
                 if (this.appDomainEventSources != null)
                 {
                     // Enumeration over concurrent queue is thread-safe.
@@ -85,6 +91,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener
             }
             finally
             {
+                // No matter what problems we encounter with enabling EventSources, we should note that we have been initialized.
                 this.initialized = true;
             }
         }

--- a/src/Adapters/EventSource.Netstandard13/Implementation/EventDataExtensions.cs
+++ b/src/Adapters/EventSource.Netstandard13/Implementation/EventDataExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Implementation
             }
             if (eventSourceEvent.RelatedActivityId != default(Guid))
             {
-                telemetry.AddProperty(nameof(EventWrittenEventArgs.RelatedActivityId), eventSourceEvent.RelatedActivityId.ToString());
+                telemetry.AddProperty(nameof(EventWrittenEventArgs.RelatedActivityId), ActivityPathDecoder.GetActivityPathString(eventSourceEvent.RelatedActivityId));
             }
             telemetry.AddProperty(nameof(EventWrittenEventArgs.Channel), eventSourceEvent.Channel.GetChannelName());
             telemetry.AddProperty(nameof(EventWrittenEventArgs.Keywords), GetHexRepresentation((long)eventSourceEvent.Keywords));


### PR DESCRIPTION
Fixes [issue 109](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/issues/109)

Also fixes a small issue with RelatedActivityID standard property, which was not decoded properly in case if activity paths were used