### PR TITLE
Extensible payload handler

### DIFF
--- a/src/Adapters.Tests/EventSource.Netstandard13.Tests/EventSourceTelemetryModuleTests.cs
+++ b/src/Adapters.Tests/EventSource.Netstandard13.Tests/EventSourceTelemetryModuleTests.cs
@@ -183,6 +183,32 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Tests
             }
         }
 
+        [TestMethod]
+        [TestCategory("EventSourceListener")]
+        public void CustomPayloadProperties()
+        {
+            OnEventWrittenHandler onWrittenHandler = (EventWrittenEventArgs args, TelemetryClient client) =>
+            {
+                var traceTelemetry = new TraceTelemetry("CustomPayloadProperties", SeverityLevel.Verbose);
+                traceTelemetry.Properties.Add("CustomPayloadProperties", "true");
+                client.Track(traceTelemetry);
+            };
+
+            using (var module = new EventSourceTelemetryModule(onWrittenHandler))
+            {
+                var listeningRequest = new EventSourceListeningRequest();
+                listeningRequest.Name = TestEventSource.ProviderName;
+                module.Sources.Add(listeningRequest);
+
+                module.Initialize(GetTestTelemetryConfiguration());
+
+                TestEventSource.Default.Write("CustomPayloadProperties");
+
+                TraceTelemetry telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems[0];
+                Assert.IsTrue(telemetry.Properties.All(kvp => kvp.Key.Equals("CustomPayloadProperties") && kvp.Value.Equals("true")));
+            }
+        }
+
         // TODO: there is a known issue with EventListner that prevents it from reporting activities properly
         // This problem is fixed in .NET Core 1.1. (https://github.com/dotnet/coreclr/pull/7591), but it won't be ported
         // to .NET Desktop till 4.7.1

--- a/src/Adapters/EventSource.Netstandard13/EventSourceTelemetryModule.cs
+++ b/src/Adapters/EventSource.Netstandard13/EventSourceTelemetryModule.cs
@@ -120,7 +120,14 @@ namespace Microsoft.ApplicationInsights.EventSourceListener
             // and not that useful for production tracing. However, TPL EventSource must be enabled to get hierarchical activity IDs.
             if (this.initialized && !TplActivities.TplEventSourceGuid.Equals(eventData.EventSource.Guid))
             {
-                this.onEventWrittenHandler(eventData, this.client);
+                try
+                {
+                    this.onEventWrittenHandler(eventData, this.client);
+                }
+                catch(Exception ex)
+                {
+                    EventSourceListenerEventSource.Log.OnEventWrittenHandlerFailed(nameof(EventSourceListener.EventSourceTelemetryModule), ex.ToString());
+                }
             }
         }
 

--- a/src/Adapters/EventSource.Netstandard13/EventSourceTelemetryModule.cs
+++ b/src/Adapters/EventSource.Netstandard13/EventSourceTelemetryModule.cs
@@ -18,6 +18,8 @@ namespace Microsoft.ApplicationInsights.EventSourceListener
     using Microsoft.ApplicationInsights.TraceEvent.Shared.Implementation;
     using Microsoft.ApplicationInsights.TraceEvent.Shared.Utilities;
 
+    public delegate void OnEventWrittenHandler(EventWrittenEventArgs eventArgs, TelemetryClient client);
+
     /// <summary>
     /// A module to trace data submitted via .NET framework <seealso cref="System.Diagnostics.Tracing.EventSource" /> class.
     /// </summary>
@@ -28,14 +30,26 @@ namespace Microsoft.ApplicationInsights.EventSourceListener
         // The following does not really need to be a ConcurrentQueue, but the ConcurrentQueue has a very convenient-to-use TryDequeue method.
         private ConcurrentQueue<EventSource> appDomainEventSources;
         private List<EventSource> enabledEventSources;
+        private readonly OnEventWrittenHandler onEventWrittenHandler;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EventSourceTelemetryModule"/> class.
         /// </summary>
-        public EventSourceTelemetryModule()
+        public EventSourceTelemetryModule() : this(EventDataExtensions.Track)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventSourceTelemetryModule"/> class.
+        /// </summary>
+        /// <param name="onEventWrittenHandler">Action to be executed each time an event is written to format and send via the configured <see cref="TelemetryClient"/></param>
+        public EventSourceTelemetryModule(OnEventWrittenHandler onEventWrittenHandler)
+        {
+            if (onEventWrittenHandler == null) throw new ArgumentNullException(nameof(onEventWrittenHandler));
+
             this.Sources = new List<EventSourceListeningRequest>();
             this.enabledEventSources = new List<EventSource>();
+            this.onEventWrittenHandler = onEventWrittenHandler;
         }
 
         /// <summary>
@@ -109,7 +123,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener
             // and not that useful for production tracing. However, TPL EventSource must be enabled to get hierarchical activity IDs.
             if (this.initialized && !TplActivities.TplEventSourceGuid.Equals(eventData.EventSource.Guid))
             {
-                eventData.Track(this.client);
+                this.onEventWrittenHandler(eventData, this.client);
             }
         }
 

--- a/src/Adapters/EventSource.Netstandard13/Implementation/EventDataExtensions.cs
+++ b/src/Adapters/EventSource.Netstandard13/Implementation/EventDataExtensions.cs
@@ -94,8 +94,8 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Implementation
             Debug.Assert(client != null, "Should always receive a valid client");
 
             var telemetry = eventSourceEvent.CreateTraceTelementry()
-                .PopulateStandardProperties(eventSourceEvent)
-                .PopulatePayloadProperties(eventSourceEvent);
+                .PopulatePayloadProperties(eventSourceEvent)
+                .PopulateStandardProperties(eventSourceEvent);
 
             client.Track(telemetry);
         }

--- a/src/Adapters/EventSource.Netstandard13/Implementation/EventDataExtensions.cs
+++ b/src/Adapters/EventSource.Netstandard13/Implementation/EventDataExtensions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Implementation
         /// </summary>
         /// <param name="eventSourceEvent">The source for the telemetry data.</param>
         /// <param name="client">Client to track the data with.</param>
-        public static void Track(this EventWrittenEventArgs eventSourceEvent, TelemetryClient client)
+        internal static void Track(this EventWrittenEventArgs eventSourceEvent, TelemetryClient client)
         {
             Debug.Assert(client != null, "Should always receive a valid client");
 

--- a/src/Adapters/EventSource.Netstandard13/Implementation/EventDataExtensions.cs
+++ b/src/Adapters/EventSource.Netstandard13/Implementation/EventDataExtensions.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Implementation
         {
             Debug.Assert(client != null, "Should always receive a valid client");
 
-            var telemetry = eventSourceEvent.ToTraceTelementry()
+            var telemetry = eventSourceEvent.CreateTraceTelementry()
                 .PopulateStandardProperties(eventSourceEvent)
                 .PopulatePayloadProperties(eventSourceEvent);
 

--- a/src/Adapters/EventSource.Netstandard13/Implementation/EventDataExtensions.cs
+++ b/src/Adapters/EventSource.Netstandard13/Implementation/EventDataExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Implementation
         /// Creates a TraceTelemetry out of an EventSource event.
         /// </summary>
         /// <param name="eventSourceEvent">The source for the telemetry data.</param>
-        public static TraceTelemetry ToTraceTelementry(this EventWrittenEventArgs eventSourceEvent)
+        public static TraceTelemetry CreateTraceTelementry(this EventWrittenEventArgs eventSourceEvent)
         {
             string formattedMessage = null;
             if (eventSourceEvent.Message != null)

--- a/src/Adapters/EventSource.Shared/EventSource.Shared/Implementation/EventSourceListenerEventSource.cs
+++ b/src/Adapters/EventSource.Shared/EventSource.Shared/Implementation/EventSourceListenerEventSource.cs
@@ -23,6 +23,7 @@ namespace Microsoft.ApplicationInsights.TraceEvent.Shared.Implementation
         private const int FailedToEnableProvidersEventId = 2;
         private const int ModuleInitializationFailedEventId = 3;
         private const int UnauthorizedAccessEventId = 4;
+        private const int OnEventWrittenHandlerFailure = 5;
 
         private EventSourceListenerEventSource()
         {
@@ -60,6 +61,12 @@ namespace Microsoft.ApplicationInsights.TraceEvent.Shared.Implementation
         public void AccessDenied(string moduleName, string details, string applicationName = null)
         {
             this.WriteEvent(UnauthorizedAccessEventId, moduleName, details, applicationName ?? this.ApplicationName);
+        }
+
+        [Event(OnEventWrittenHandlerFailure, Level = EventLevel.Error, Message = "{0}: Failure while handling event")]
+        public void OnEventWrittenHandlerFailed(string moduleName, string details, string applicationName = null)
+        {
+            this.WriteEvent(OnEventWrittenHandlerFailure, moduleName, details, applicationName ?? this.ApplicationName);
         }
 
         [NonEvent]


### PR DESCRIPTION
We use Tracelogging extensively in our system and we often log nested EventData objects via Write<T>. The current implementation doesn't work for this scenario since it just calls ToString() on each value in the Payload collection. This change allows for implementing your own handler for converting EventWrittenEventArgs to TraceTelemetry.