### PR TITLE
sdl upgrade NLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Update Application Insights API reference to [2.5.0-beta1]
 - Removed framework 4.0 support
 - For EventSourceTelemetryModule, allows black list the event sources. Drops the events to those in the list.
+- Update NLog reference to [4.4.12](https://github.com/NLog/NLog/releases/tag/v4.4.12)
 
 ### Version 2.4.0
 - Update Application Insights API reference to [2.4.0]

--- a/src/NLogTarget/NLogTarget.csproj
+++ b/src/NLogTarget/NLogTarget.csproj
@@ -41,7 +41,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.5.0-beta1" />
-    <PackageReference Include="NLog" Version="4.3.11" />
+    <PackageReference Include="NLog" Version="4.4.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
+++ b/test/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microbuild.Core" Version="0.2.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NLog" Version="4.3.11" />
+    <PackageReference Include="NLog" Version="4.4.12" />
     <ProjectReference Include="..\..\src\NLogTarget\NLogTarget.csproj" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>


### PR DESCRIPTION
sdl has recommended but not required that we upgrade our version of NLog.

This is a trivial non-breaking change, no real reason not to do it.
This will not change the min-required version (4.3.8).

I ran all tests and they continue to pass.