### PR TITLE
remove autocollection of userId from Log4Net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog 
 
-### Version 2.6.0-beta
-
+### Version 2.6.0-beta1
 - Include NLog GlobalDiagnosticsContext properties.
+- Remove automatic collection of User Id (https://github.com/Microsoft/ApplicationInsights-dotnet-logging/issues/153)
 
 ### Version 2.5.0
 - Update Application Insights API reference to [2.5.0]

--- a/Logging.sln
+++ b/Logging.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{EE933574-C82B-4E59-A0D1-05328197B937}"
 EndProject
@@ -13,6 +13,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xdt.Tests", "test\Xdt.Tests
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{117E14CF-5656-42BD-B64E-93142160B6FA}"
 	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
 		CodeCov.ps1 = CodeCov.ps1
 		Common.props = Common.props
 		Common.targets = Common.targets

--- a/src/Log4NetAppender/ApplicationInsightsAppender.cs
+++ b/src/Log4NetAppender/ApplicationInsightsAppender.cs
@@ -142,7 +142,6 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender
         private void BuildCustomProperties(LoggingEvent loggingEvent, ITelemetry trace)
         {
             trace.Timestamp = loggingEvent.TimeStamp;
-            trace.Context.User.AuthenticatedUserId = loggingEvent.UserName;
 
             IDictionary<string, string> metaData;
             

--- a/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
+++ b/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
@@ -162,20 +162,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
 
             Assert.IsNull(TelemetrySender.ValidateEndpointSend(telemetry));
         }
-
-        [TestMethod]
-        [TestCategory("Log4NetAppender")]
-        public void Log4NetSetsAuthenticatedUser()
-        {
-            this.appendableLogger.Logger.Debug("Trace Debug");
-
-            var sentItems = this.appendableLogger.SentItems;
-            Assert.AreEqual(1, sentItems.Length);
-
-            var telemetry = (TraceTelemetry)sentItems[0];
-            Assert.IsNotNull(telemetry.Context.User.AuthenticatedUserId);
-        }
-
+        
         [TestMethod]
         [TestCategory("Log4NetAppender")]
         public void Log4NetAddsCustomProperties()

--- a/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
+++ b/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
@@ -162,7 +162,20 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
 
             Assert.IsNull(TelemetrySender.ValidateEndpointSend(telemetry));
         }
-        
+
+        [TestMethod]
+        [TestCategory("Log4NetAppender")]
+        public void Log4NetDoesNotSetAuthenticatedUser()
+        {
+            this.appendableLogger.Logger.Debug("Trace Debug");
+
+            var sentItems = this.appendableLogger.SentItems;
+            Assert.AreEqual(1, sentItems.Length);
+
+            var telemetry = (TraceTelemetry)sentItems[0];
+            Assert.IsNull(telemetry.Context.User.AuthenticatedUserId);
+        }
+
         [TestMethod]
         [TestCategory("Log4NetAppender")]
         public void Log4NetAddsCustomProperties()


### PR DESCRIPTION
Remove UserId from Log4Net. Update test and changelog.
#153 