### PR TITLE
add fxcop analyzer

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -21,7 +21,8 @@
     <Optimize>true</Optimize>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Need to disable WarningsAsErrors until all FxCop issues are fixed. -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>
 

--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -17,12 +17,16 @@
     
     <PreReleaseVersionFileName>.PreReleaseVersion</PreReleaseVersionFileName>
     <PreReleaseVersionFilePath>$(MSBuildThisFileDirectory)$(PreReleaseVersionFileName)</PreReleaseVersionFilePath>
-
+    <!--
+      Pre-release version is used to distinguish internally built NuGet packages.
+      Pre-release version = Minutes since semantic version was set, divided by 5 (to make it fit in a UInt16 (max 65535 = ~7 months).
+    -->
     <PreReleaseVersion>$([MSBuild]::Divide($([System.DateTime]::Now.Subtract($([System.DateTime]::Parse($(SemanticVersionDate)))).TotalMinutes), 5).ToString('F0'))</PreReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PackageVersion)'==''">
-    <PackageVersion>$(SemanticVersionMajor).$(SemanticVersionMinor).$(SemanticVersionPatch)-$(PreReleaseMilestone)</PackageVersion>
+    <PackageVersion>$(SemanticVersionMajor).$(SemanticVersionMinor).$(SemanticVersionPatch)</PackageVersion>
+    <PackageVersion Condition="'$(PreReleaseMilestone)' != ''">$(PackageVersion)-$(PreReleaseMilestone)</PackageVersion>
     <PackageVersion Condition="'$(StableRelease)' != 'True'">$(PackageVersion)-build$(PreReleaseVersion)</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
+++ b/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
@@ -41,7 +41,6 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>

--- a/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
+++ b/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
@@ -39,6 +39,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/EtwCollector/EtwCollector.csproj
+++ b/src/EtwCollector/EtwCollector.csproj
@@ -39,7 +39,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>

--- a/src/EtwCollector/EtwCollector.csproj
+++ b/src/EtwCollector/EtwCollector.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/EtwCollector/EtwCollector.csproj
+++ b/src/EtwCollector/EtwCollector.csproj
@@ -37,7 +37,10 @@
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/EventSource.Shared/EventSource.Shared/Implementation/EventSourceListenerEventSource.cs
+++ b/src/EventSource.Shared/EventSource.Shared/Implementation/EventSourceListenerEventSource.cs
@@ -19,6 +19,8 @@ namespace Microsoft.ApplicationInsights.TraceEvent.Shared.Implementation
         public const string ProviderName = "Microsoft-ApplicationInsights-Extensibility-EventSourceListener";
         public static readonly EventSourceListenerEventSource Log = new EventSourceListenerEventSource();
 
+        public readonly string ApplicationName;
+
         private const int NoEventSourcesConfiguredEventId = 1;
         private const int FailedToEnableProvidersEventId = 2;
         private const int ModuleInitializationFailedEventId = 3;
@@ -27,13 +29,7 @@ namespace Microsoft.ApplicationInsights.TraceEvent.Shared.Implementation
 
         private EventSourceListenerEventSource()
         {
-            this.ApplicationName = this.GetApplicationName();
-        }
-
-        public string ApplicationName
-        {
-            [NonEvent]
-            get;
+            this.ApplicationName = GetApplicationName();
         }
 
         [Event(NoEventSourcesConfiguredEventId, Level = EventLevel.Warning, Keywords = Keywords.Configuration, Message = "No Sources configured for the {1}")]
@@ -67,7 +63,7 @@ namespace Microsoft.ApplicationInsights.TraceEvent.Shared.Implementation
         }
 
         [NonEvent]
-        private string GetApplicationName()
+        private static string GetApplicationName()
         {
             string name;
             try

--- a/src/EventSourceListener/EventSourceListener.csproj
+++ b/src/EventSourceListener/EventSourceListener.csproj
@@ -40,7 +40,6 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>

--- a/src/EventSourceListener/EventSourceListener.csproj
+++ b/src/EventSourceListener/EventSourceListener.csproj
@@ -38,6 +38,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Log4NetAppender/ApplicationInsightsAppender.cs
+++ b/src/Log4NetAppender/ApplicationInsightsAppender.cs
@@ -100,57 +100,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender
             }
         }
 
-        private void SendException(LoggingEvent loggingEvent)
-        {
-            try
-            {
-                var exceptionTelemetry = new ExceptionTelemetry(loggingEvent.ExceptionObject)
-                {
-                    SeverityLevel = this.GetSeverityLevel(loggingEvent.Level)
-                };
-
-                string message = null;
-                if (loggingEvent.RenderedMessage != null)
-                {
-                    message = this.RenderLoggingEvent(loggingEvent);
-                }
-
-                if (!string.IsNullOrEmpty(message))
-                {
-                    exceptionTelemetry.Properties.Add("Message", message);
-                }
-
-                this.BuildCustomProperties(loggingEvent, exceptionTelemetry);
-                this.telemetryClient.Track(exceptionTelemetry);
-            }
-            catch (ArgumentNullException exception)
-            {
-                throw new LogException(exception.Message, exception);
-            }
-        }
-
-        private void SendTrace(LoggingEvent loggingEvent)
-        {
-            try
-            {
-                loggingEvent.GetProperties();
-                string message = loggingEvent.RenderedMessage != null ? this.RenderLoggingEvent(loggingEvent) : "Log4Net Trace";
-
-                var trace = new TraceTelemetry(message)
-                {
-                    SeverityLevel = this.GetSeverityLevel(loggingEvent.Level)
-                };
-
-                this.BuildCustomProperties(loggingEvent, trace);
-                this.telemetryClient.Track(trace);
-            }
-            catch (ArgumentNullException exception)
-            {
-                throw new LogException(exception.Message, exception);
-            }
-        }
-
-        private void BuildCustomProperties(LoggingEvent loggingEvent, ITelemetry trace)
+        private static void BuildCustomProperties(LoggingEvent loggingEvent, ITelemetry trace)
         {
             trace.Timestamp = loggingEvent.TimeStamp;
 
@@ -197,7 +147,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender
             }
         }
 
-        private SeverityLevel? GetSeverityLevel(Level logginEventLevel)
+        private static SeverityLevel? GetSeverityLevel(Level logginEventLevel)
         {
             if (logginEventLevel == null)
             {
@@ -225,6 +175,56 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender
             }
 
             return SeverityLevel.Critical;
+        }
+
+        private void SendException(LoggingEvent loggingEvent)
+        {
+            try
+            {
+                var exceptionTelemetry = new ExceptionTelemetry(loggingEvent.ExceptionObject)
+                {
+                    SeverityLevel = GetSeverityLevel(loggingEvent.Level)
+                };
+
+                string message = null;
+                if (loggingEvent.RenderedMessage != null)
+                {
+                    message = this.RenderLoggingEvent(loggingEvent);
+                }
+
+                if (!string.IsNullOrEmpty(message))
+                {
+                    exceptionTelemetry.Properties.Add("Message", message);
+                }
+
+                BuildCustomProperties(loggingEvent, exceptionTelemetry);
+                this.telemetryClient.Track(exceptionTelemetry);
+            }
+            catch (ArgumentNullException exception)
+            {
+                throw new LogException(exception.Message, exception);
+            }
+        }
+
+        private void SendTrace(LoggingEvent loggingEvent)
+        {
+            try
+            {
+                loggingEvent.GetProperties();
+                string message = loggingEvent.RenderedMessage != null ? this.RenderLoggingEvent(loggingEvent) : "Log4Net Trace";
+
+                var trace = new TraceTelemetry(message)
+                {
+                    SeverityLevel = GetSeverityLevel(loggingEvent.Level)
+                };
+
+                BuildCustomProperties(loggingEvent, trace);
+                this.telemetryClient.Track(trace);
+            }
+            catch (ArgumentNullException exception)
+            {
+                throw new LogException(exception.Message, exception);
+            }
         }
     }
 }

--- a/src/Log4NetAppender/Log4NetAppender.csproj
+++ b/src/Log4NetAppender/Log4NetAppender.csproj
@@ -29,7 +29,10 @@
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Log4NetAppender/Log4NetAppender.csproj
+++ b/src/Log4NetAppender/Log4NetAppender.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Log4NetAppender/Log4NetAppender.csproj
+++ b/src/Log4NetAppender/Log4NetAppender.csproj
@@ -31,7 +31,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>

--- a/src/NLogTarget/ApplicationInsightsTarget.cs
+++ b/src/NLogTarget/ApplicationInsightsTarget.cs
@@ -96,13 +96,13 @@ namespace Microsoft.ApplicationInsights.NLogTarget
                 if (!string.IsNullOrEmpty(contextProperty.Name))
                 {
                     string propertyValue = contextProperty.Layout?.Render(logEvent);
-                    this.PopulatePropertyBag(propertyBag, contextProperty.Name, propertyValue);
+                    PopulatePropertyBag(propertyBag, contextProperty.Name, propertyValue);
                 }
             }
 
             if (logEvent.HasProperties)
             {
-                this.LoadLogEventProperties(logEvent, propertyBag);
+                LoadLogEventProperties(logEvent, propertyBag);
             }
         }
 
@@ -174,34 +174,7 @@ namespace Microsoft.ApplicationInsights.NLogTarget
             }
         }
 
-        private void SendException(LogEventInfo logEvent)
-        {
-            var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception)
-            {
-                SeverityLevel = this.GetSeverityLevel(logEvent.Level)
-            };
-
-            string logMessage = this.Layout.Render(logEvent);
-            exceptionTelemetry.Properties.Add("Message", logMessage);
-
-            this.BuildPropertyBag(logEvent, exceptionTelemetry);
-            this.telemetryClient.Track(exceptionTelemetry);
-        }
-
-        private void SendTrace(LogEventInfo logEvent)
-        {
-            string logMessage = this.Layout.Render(logEvent);
-
-            var trace = new TraceTelemetry(logMessage)
-            {
-                SeverityLevel = this.GetSeverityLevel(logEvent.Level)
-            };
-
-            this.BuildPropertyBag(logEvent, trace);
-            this.telemetryClient.Track(trace);
-        }
-
-        private void LoadLogEventProperties(LogEventInfo logEvent, IDictionary<string, string> propertyBag)
+        private static void LoadLogEventProperties(LogEventInfo logEvent, IDictionary<string, string> propertyBag)
         {
             if (logEvent.Properties?.Count > 0)
             {
@@ -209,12 +182,12 @@ namespace Microsoft.ApplicationInsights.NLogTarget
                 {
                     string key = keyValuePair.Key.ToString();
                     object valueObj = keyValuePair.Value;
-                    this.PopulatePropertyBag(propertyBag, key, valueObj);
+                    PopulatePropertyBag(propertyBag, key, valueObj);
                 }
             }
         }
 
-        private void PopulatePropertyBag(IDictionary<string, string> propertyBag, string key, object valueObj)
+        private static void PopulatePropertyBag(IDictionary<string, string> propertyBag, string key, object valueObj)
         {
             if (valueObj == null)
             {
@@ -235,7 +208,7 @@ namespace Microsoft.ApplicationInsights.NLogTarget
             propertyBag.Add(key, value);
         }
 
-        private SeverityLevel? GetSeverityLevel(LogLevel logEventLevel)
+        private static SeverityLevel? GetSeverityLevel(LogLevel logEventLevel)
         {
             if (logEventLevel == null)
             {
@@ -270,6 +243,33 @@ namespace Microsoft.ApplicationInsights.NLogTarget
 
             // The only possible value left if OFF but we should never get here in this case
             return null;
+        }
+
+        private void SendException(LogEventInfo logEvent)
+        {
+            var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception)
+            {
+                SeverityLevel = GetSeverityLevel(logEvent.Level)
+            };
+
+            string logMessage = this.Layout.Render(logEvent);
+            exceptionTelemetry.Properties.Add("Message", logMessage);
+
+            this.BuildPropertyBag(logEvent, exceptionTelemetry);
+            this.telemetryClient.Track(exceptionTelemetry);
+        }
+
+        private void SendTrace(LogEventInfo logEvent)
+        {
+            string logMessage = this.Layout.Render(logEvent);
+
+            var trace = new TraceTelemetry(logMessage)
+            {
+                SeverityLevel = GetSeverityLevel(logEvent.Level)
+            };
+
+            this.BuildPropertyBag(logEvent, trace);
+            this.telemetryClient.Track(trace);
         }
     }
 }

--- a/src/NLogTarget/NLogTarget.csproj
+++ b/src/NLogTarget/NLogTarget.csproj
@@ -29,7 +29,10 @@
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/NLogTarget/NLogTarget.csproj
+++ b/src/NLogTarget/NLogTarget.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/NLogTarget/NLogTarget.csproj
+++ b/src/NLogTarget/NLogTarget.csproj
@@ -31,7 +31,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>

--- a/src/TraceListener/ApplicationInsightsTraceListener.cs
+++ b/src/TraceListener/ApplicationInsightsTraceListener.cs
@@ -104,7 +104,7 @@ namespace Microsoft.ApplicationInsights.TraceListener
             }
 
             var trace = new TraceTelemetry(message);
-            this.CreateTraceData(eventType, id, trace);
+            CreateTraceData(eventType, id, trace);
             this.TelemetryClient.Track(trace);
         }
 
@@ -145,7 +145,7 @@ namespace Microsoft.ApplicationInsights.TraceListener
 
             string message = string.Join(", ", data.Select(d => d == null ? string.Empty : d.ToString()));
             var trace = new TraceTelemetry(message);
-            this.CreateTraceData(eventType, id, trace);                       
+            CreateTraceData(eventType, id, trace);                       
             this.TelemetryClient.Track(trace);
         }
 
@@ -167,7 +167,7 @@ namespace Microsoft.ApplicationInsights.TraceListener
             }
 
             var trace = new TraceTelemetry(message);
-            this.CreateTraceData(TraceEventType.Verbose, null, trace);
+            CreateTraceData(TraceEventType.Verbose, null, trace);
             this.TelemetryClient.Track(trace);
         }
 
@@ -188,9 +188,9 @@ namespace Microsoft.ApplicationInsights.TraceListener
             this.TelemetryClient.Flush();
         }
 
-        private void CreateTraceData(TraceEventType eventType, int? id, TraceTelemetry trace)
+        private static void CreateTraceData(TraceEventType eventType, int? id, TraceTelemetry trace)
         {
-            trace.SeverityLevel = this.GetSeverityLevel(eventType);
+            trace.SeverityLevel = GetSeverityLevel(eventType);
             
             IDictionary<string, string> metaData = trace.Properties;
             
@@ -200,7 +200,7 @@ namespace Microsoft.ApplicationInsights.TraceListener
             }
         }
 
-        private SeverityLevel GetSeverityLevel(TraceEventType eventType)
+        private static SeverityLevel GetSeverityLevel(TraceEventType eventType)
         {
             // TraceEventType.Resume, TraceEventType.Start, TraceEventType.Stop,
             // TraceEventType.Suspend, TraceEventType.Transfer, TraceEventType.Verbose

--- a/src/TraceListener/TraceListener.csproj
+++ b/src/TraceListener/TraceListener.csproj
@@ -27,7 +27,10 @@
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />    
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>    
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/TraceListener/TraceListener.csproj
+++ b/src/TraceListener/TraceListener.csproj
@@ -26,7 +26,8 @@
   <ItemGroup>
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0">
       <PrivateAssets>All</PrivateAssets>
-    </PackageReference>    
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" />    
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/TraceListener/TraceListener.csproj
+++ b/src/TraceListener/TraceListener.csproj
@@ -29,7 +29,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>    
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>All</PrivateAssets>


### PR DESCRIPTION
Add the FxCop Analyzer to Non-Test projects.

This analyzer identifies **SEVERAL** compiler errors. 
If you're bored one afternoon, feel free to pull this branch and fix a couple! :)

![dreamwork](https://user-images.githubusercontent.com/28785781/37181041-45284c68-22e0-11e8-8c5c-fc0322876351.jpg)
