### PR TITLE
NLog ApplicationInsightsTarget Flush with async delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog 
 
 ### Version 2.6.0-beta3
+- [NetStandard Support for TraceListener](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/166)
 - [NetStandard Support for NLog and log4net](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/167)
 - [NLog and log4net can Flush](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/167)
 - Update log4net reference to [2.0.6](https://www.nuget.org/packages/log4net/2.0.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog 
 
+### Version 2.6.0
+- [NLog Flush should include async delay](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/176)
+
 ### Version 2.6.0-beta3
 - [NetStandard Support for TraceListener](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/166)
 - [NetStandard Support for NLog and log4net](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/167)

--- a/src/NLogTarget/ApplicationInsightsTarget.cs
+++ b/src/NLogTarget/ApplicationInsightsTarget.cs
@@ -138,8 +138,8 @@ namespace Microsoft.ApplicationInsights.NLogTarget
                 else
                 {
                     // Documentation says it is important to wait after flush, else nothing will happen
-                    // https://docs.microsoft.com/en-us/azure/application-insights/app-insights-api-custom-events-metrics#flushing-data
-                    System.Threading.Tasks.Task.Delay(500).ContinueWith((task) => asyncContinuation(null));
+                    // https://docs.microsoft.com/azure/application-insights/app-insights-api-custom-events-metrics#flushing-data
+                    System.Threading.Tasks.Task.Delay(TimeSpan.FromMilliseconds(500)).ContinueWith((task) => asyncContinuation(null));
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
But only when something to flush. Partially resolves #177 for NLog (Probably also an issue for all other logging destinations)