### PR TITLE
Prevent double telemetry if DiagnosticSourceTelemetryModule is initialized twice

### DIFF
--- a/src/DiagnosticSourceListener/DiagnosticSourceTelemetryModule.cs
+++ b/src/DiagnosticSourceListener/DiagnosticSourceTelemetryModule.cs
@@ -9,6 +9,7 @@ namespace Microsoft.ApplicationInsights.DiagnosticSourceListener
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Threading;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Implementation;
@@ -46,7 +47,11 @@ namespace Microsoft.ApplicationInsights.DiagnosticSourceListener
             // Protect against multiple subscriptions if Initialize is called twice
             if (this.allDiagnosticListenersSubscription == null)
             {
-                this.allDiagnosticListenersSubscription = DiagnosticListener.AllListeners.Subscribe(this);
+                var subscription = DiagnosticListener.AllListeners.Subscribe(this);
+                if (Interlocked.CompareExchange(ref this.allDiagnosticListenersSubscription, subscription, null) != null)
+                {
+                    subscription.Dispose();
+                }
             }
         }
 

--- a/src/DiagnosticSourceListener/DiagnosticSourceTelemetryModule.cs
+++ b/src/DiagnosticSourceListener/DiagnosticSourceTelemetryModule.cs
@@ -38,9 +38,16 @@ namespace Microsoft.ApplicationInsights.DiagnosticSourceListener
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            this.client = new TelemetryClient(configuration);
-            this.client.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("dsl:");
-            this.allDiagnosticListenersSubscription = DiagnosticListener.AllListeners.Subscribe(this);
+            var telemetryClient = new TelemetryClient(configuration);
+            telemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("dsl:");
+
+            this.client = telemetryClient;
+
+            // Protect against multiple subscriptions if Initialize is called twice
+            if (this.allDiagnosticListenersSubscription == null)
+            {
+                this.allDiagnosticListenersSubscription = DiagnosticListener.AllListeners.Subscribe(this);
+            }
         }
 
         /// <summary>

--- a/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceTelemetryModuleTests.cs
+++ b/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceTelemetryModuleTests.cs
@@ -60,6 +60,24 @@ namespace Microsoft.ApplicationInsights.DiagnosticSourceListener.Tests
         }
 
         [TestMethod]
+        public void ReportsSingleEventEvenIfInitializedMoreThanOnce()
+        {
+            using (var module = new DiagnosticSourceTelemetryModule())
+            {
+                var testDiagnosticSource = new TestDiagnosticSource();
+                var listeningRequest = new DiagnosticSourceListeningRequest(testDiagnosticSource.Name);
+                module.Sources.Add(listeningRequest);
+
+                module.Initialize(GetTestTelemetryConfiguration());
+                module.Initialize(GetTestTelemetryConfiguration());
+
+                testDiagnosticSource.Write("JustOnce", new { Index = 8888 });
+
+                Assert.AreEqual(1, this.adapterHelper.Channel.SentItems.Length);
+            }
+        }
+
+        [TestMethod]
         public void HandlesPropertiesWithNullValues()
         {
             using (var module = new DiagnosticSourceTelemetryModule())


### PR DESCRIPTION
Prevent double telemetry if DiagnosticSourceTelemetryModule is initialied twice.

Fixes https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/653