### PR TITLE
Fix FxCop violations

### DIFF
--- a/src/DiagnosticSourceListener/DiagnosticSourceListeningRequest.cs
+++ b/src/DiagnosticSourceListener/DiagnosticSourceListeningRequest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ApplicationInsights.DiagnosticSourceListener
                 return false;
             }
 
-            return this.Name == other.Name;
+            return string.Equals(this.Name, other.Name, System.StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/src/EtwCollector/AITraceEventSession.cs
+++ b/src/EtwCollector/AITraceEventSession.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ApplicationInsights.EtwCollector
     /// <summary>
     /// A wrapper of <see cref="Microsoft.Diagnostics.Tracing.Session.TraceEventSession"/>.
     /// </summary>
-    internal class AITraceEventSession : ITraceEventSession, IDisposable
+    internal sealed class AITraceEventSession : ITraceEventSession, IDisposable
     {
         private TraceEventSession session;
 

--- a/src/EventSource.Shared/EventSource.Shared/Implementation/EventSourceListenerEventSource.cs
+++ b/src/EventSource.Shared/EventSource.Shared/Implementation/EventSourceListenerEventSource.cs
@@ -34,9 +34,6 @@ namespace Microsoft.ApplicationInsights.TraceEvent.Shared.Implementation
         {
             [NonEvent]
             get;
-
-            [NonEvent]
-            private set;
         }
 
         [Event(NoEventSourcesConfiguredEventId, Level = EventLevel.Warning, Keywords = Keywords.Configuration, Message = "No Sources configured for the {1}")]

--- a/src/EventSourceListener/EventSourceListeningRequestBase.cs
+++ b/src/EventSourceListener/EventSourceListeningRequestBase.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener
                 return false;
             }
 
-            return this.Name == other.Name && this.PrefixMatch == other.PrefixMatch;
+            return string.Equals(this.Name, other.Name, System.StringComparison.Ordinal) && this.PrefixMatch == other.PrefixMatch;
         }
 
         /// <summary>

--- a/src/EventSourceListener/EventSourceTelemetryModule.cs
+++ b/src/EventSourceListener/EventSourceTelemetryModule.cs
@@ -221,7 +221,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener
                 this.EnableEvents(eventSource, EventLevel.LogAlways, (EventKeywords)TplActivities.TaskFlowActivityIdsKeyword);
                 this.enabledEventSources.Enqueue(eventSource);
             }
-            else if (eventSource.Name == EventSourceListenerEventSource.ProviderName)
+            else if (string.Equals(eventSource.Name, EventSourceListenerEventSource.ProviderName, StringComparison.Ordinal))
             {
                 // Tracking ourselves does not make much sense
                 return;
@@ -236,7 +236,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener
                     // tasks, which then itself also fires Threadpool events on FrameworkEventSource at unexpected locations, and trigger deadlocks.
                     // Hence, we like special case this and mask out Threadpool events.
                     EventKeywords keywords = listeningRequest.Keywords;
-                    if (listeningRequest.Name == "System.Diagnostics.Eventing.FrameworkEventSource")
+                    if (string.Equals(listeningRequest.Name, "System.Diagnostics.Eventing.FrameworkEventSource", StringComparison.Ordinal))
                     {
                         // Turn off the Threadpool | ThreadTransfer keyword. Definition is at http://referencesource.microsoft.com/#mscorlib/system/diagnostics/eventing/frameworkeventsource.cs
                         // However, if keywords was to begin with, then we need to set it to All first, which is 0xFFFFF....

--- a/src/NLogTarget/ApplicationInsightsTarget.cs
+++ b/src/NLogTarget/ApplicationInsightsTarget.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ApplicationInsights.NLogTarget
         {
             if (logEvent == null)
             {
-                throw new ArgumentNullException("logEvent");
+                throw new ArgumentNullException(nameof(logEvent));
             }
 
             this.lastLogEventTime = DateTime.UtcNow;
@@ -207,7 +207,7 @@ namespace Microsoft.ApplicationInsights.NLogTarget
             string value = valueObj.ToString();
             if (propertyBag.ContainsKey(key))
             {
-                if (value == propertyBag[key])
+                if (string.Equals(value, propertyBag[key], StringComparison.Ordinal))
                 {
                     return;
                 }

--- a/src/TraceListener/ApplicationInsightsTraceListener.cs
+++ b/src/TraceListener/ApplicationInsightsTraceListener.cs
@@ -104,7 +104,7 @@ namespace Microsoft.ApplicationInsights.TraceListener
             }
 
             var trace = new TraceTelemetry(message);
-            this.CreateTraceData(eventCache, eventType, id, trace);
+            this.CreateTraceData(eventType, id, trace);
             this.TelemetryClient.Track(trace);
         }
 
@@ -145,7 +145,7 @@ namespace Microsoft.ApplicationInsights.TraceListener
 
             string message = string.Join(", ", data.Select(d => d == null ? string.Empty : d.ToString()));
             var trace = new TraceTelemetry(message);
-            this.CreateTraceData(eventCache, eventType, id, trace);                       
+            this.CreateTraceData(eventType, id, trace);                       
             this.TelemetryClient.Track(trace);
         }
 
@@ -167,7 +167,7 @@ namespace Microsoft.ApplicationInsights.TraceListener
             }
 
             var trace = new TraceTelemetry(message);
-            this.CreateTraceData(new TraceEventCache(), TraceEventType.Verbose, null, trace);
+            this.CreateTraceData(TraceEventType.Verbose, null, trace);
             this.TelemetryClient.Track(trace);
         }
 
@@ -188,7 +188,7 @@ namespace Microsoft.ApplicationInsights.TraceListener
             this.TelemetryClient.Flush();
         }
 
-        private void CreateTraceData(TraceEventCache eventCache, TraceEventType eventType, int? id, TraceTelemetry trace)
+        private void CreateTraceData(TraceEventType eventType, int? id, TraceTelemetry trace)
         {
             trace.SeverityLevel = this.GetSeverityLevel(eventType);
             

--- a/test/CommonTestShared/SdkVersionHelper.cs
+++ b/test/CommonTestShared/SdkVersionHelper.cs
@@ -6,7 +6,7 @@
 
     public static class SdkVersionHelper
     {
-        public static string GetExpectedSdkVersion(Type assemblyType, string prefix)
+        public static string GetExpectedSdkVersion(string prefix)
         {
 #if NET45 || NET46
             string versionStr = typeof(SdkVersionHelper).Assembly.GetCustomAttributes(false).OfType<AssemblyFileVersionAttribute>().First().Version;

--- a/test/CommonTestShared/TelemetrySender.cs
+++ b/test/CommonTestShared/TelemetrySender.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.CommonTestShared
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Net;
@@ -25,7 +26,7 @@
 
             HttpClient client = new HttpClient();
             var result = client.PostAsync(
-                "https://dc.services.visualstudio.com/v2/validate",
+                new Uri("https://dc.services.visualstudio.com/v2/validate"),
                 new ByteArrayContent(Encoding.UTF8.GetBytes(json))).GetAwaiter().GetResult();
 
             if (result.StatusCode != HttpStatusCode.OK)

--- a/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceTelemetryModuleTests.cs
+++ b/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceTelemetryModuleTests.cs
@@ -16,6 +16,8 @@ namespace Microsoft.ApplicationInsights.DiagnosticSourceListener.Tests
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+    using static System.Globalization.CultureInfo;
+
     [TestClass]
     [TestCategory("DiagnosticSourceListener")]
     public sealed class DiagnosticSourceTelemetryModuleTests : IDisposable
@@ -53,8 +55,8 @@ namespace Microsoft.ApplicationInsights.DiagnosticSourceListener.Tests
                 Assert.AreEqual("Hey!", telemetry.Message);
                 Assert.AreEqual(testDiagnosticSource.Name, telemetry.Properties["DiagnosticSource"]);
                 Assert.AreEqual(SeverityLevel.Information, telemetry.SeverityLevel);
-                Assert.AreEqual(1234.ToString(), telemetry.Properties["Prop1"]);
-                string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(typeof(DiagnosticSourceTelemetryModule), prefix: "dsl:");
+                Assert.AreEqual(1234.ToString(InvariantCulture), telemetry.Properties["Prop1"]);
+                string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "dsl:");
                 Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
             }
         }

--- a/test/EtwCollector.Net451.Tests/EventSourceModuleDiagnosticListener.cs
+++ b/test/EtwCollector.Net451.Tests/EventSourceModuleDiagnosticListener.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
 
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
-            if (eventSource.Name == "Microsoft-ApplicationInsights-Extensibility-EventSourceListener")
+            if (string.Equals(eventSource.Name, "Microsoft-ApplicationInsights-Extensibility-EventSourceListener", System.StringComparison.Ordinal))
             {
                 EnableEvents(eventSource, EventLevel.LogAlways);
             }

--- a/test/EtwCollector.Net451.Tests/TraceEventSessionMock.cs
+++ b/test/EtwCollector.Net451.Tests/TraceEventSessionMock.cs
@@ -12,7 +12,7 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
     using Diagnostics.Tracing.Session;
     using Microsoft.ApplicationInsights.EtwCollector;
 
-    internal class TraceEventSessionMock : ITraceEventSession
+    internal sealed class TraceEventSessionMock : ITraceEventSession
     {
         private bool isFakeAccessDenied;
 
@@ -81,7 +81,9 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
             return true;
         }
 
+#pragma warning disable CA1801 // Review unused parameters
         public bool Stop(bool noThrow = false)
+#pragma warning restore CA1801 // Review unused parameters
         {
             throw new NotImplementedException();
         }

--- a/test/EtwCollector.Net451.Tests/TraceTelemetryComparer.cs
+++ b/test/EtwCollector.Net451.Tests/TraceTelemetryComparer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
                 return Comparer.DefaultInvariant.Compare(x, y);
             }
 
-            bool equal = template.Message == actual.Message
+            bool equal = string.Equals(template.Message, actual.Message, System.StringComparison.Ordinal)
                 && template.SeverityLevel == actual.SeverityLevel
                 && HaveProperties(template.Properties, actual.Properties);
             if (equal)
@@ -48,7 +48,7 @@ namespace Microsoft.ApplicationInsights.EtwTelemetryCollector.Tests
                     return false;
                 }
 
-                if (kvp.Value != actualValue)
+                if (!string.Equals(kvp.Value, actualValue, System.StringComparison.Ordinal))
                 {
                     return false;
                 }

--- a/test/EventSourceListener.netcoreapp10.Tests/EventSourceModuleDiagnosticListener.cs
+++ b/test/EventSourceListener.netcoreapp10.Tests/EventSourceModuleDiagnosticListener.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Tests
 
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
-            if (eventSource.Name == "Microsoft-ApplicationInsights-Extensibility-EventSourceListener")
+            if (string.Equals(eventSource.Name, "Microsoft-ApplicationInsights-Extensibility-EventSourceListener", StringComparison.Ordinal))
             {
                 EnableEvents(eventSource, EventLevel.LogAlways);
             }

--- a/test/EventSourceListener.netcoreapp10.Tests/TraceTelemetryComparer.cs
+++ b/test/EventSourceListener.netcoreapp10.Tests/TraceTelemetryComparer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Tests
                 return Comparer.DefaultInvariant.Compare(x, y);
             }
 
-            bool equal = template.Message == actual.Message
+            bool equal = string.Equals(template.Message, actual.Message, StringComparison.Ordinal)
                 && template.SeverityLevel == actual.SeverityLevel
                 && HaveProperties(template.Properties, actual.Properties);
             if (equal)
@@ -49,7 +49,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Tests
                     return false;
                 }
 
-                if (kvp.Value != actualValue)
+                if (!string.Equals(kvp.Value, actualValue, StringComparison.Ordinal))
                 {
                     return false;
                 }

--- a/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
+++ b/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
@@ -27,6 +27,8 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
     using Microsoft.ApplicationInsights.Tracing.Tests;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+    using static System.Globalization.CultureInfo;
+
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         category: "Microsoft.Design", checkId: "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "Disposing the object in the Test Cleanup")]
     [TestClass]
@@ -66,7 +68,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
         {
             string instrumentationKey = Guid.NewGuid().ToString();
             this.VerifyInitializationSuccess(
-                    () => ApplicationInsightsAppenderTests.InitializeLog4NetAIAdapter(string.Format(@"<InstrumentationKey value=""{0}"" />", instrumentationKey)),
+                    () => ApplicationInsightsAppenderTests.InitializeLog4NetAIAdapter(string.Format(InvariantCulture, @"<InstrumentationKey value=""{0}"" />", instrumentationKey)),
                     instrumentationKey);
         }
 
@@ -82,7 +84,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
             var telemetry = (TraceTelemetry)sentItems[0];
             Assert.AreNotEqual(default(DateTimeOffset), telemetry.Context);
 
-            string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(typeof(ApplicationInsightsAppender), prefix: "log4net:");
+            string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "log4net:");
             Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
         }
         
@@ -91,7 +93,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
         public void ValidateLoggingIsWorking()
         {
             string instrumentationKey = "93d9c2b7-e633-4571-8520-d391511a1df5";
-            ApplicationInsightsAppenderTests.InitializeLog4NetAIAdapter(string.Format(@"<InstrumentationKey value=""{0}"" />", instrumentationKey));
+            ApplicationInsightsAppenderTests.InitializeLog4NetAIAdapter(string.Format(InvariantCulture, @"<InstrumentationKey value=""{0}"" />", instrumentationKey));
 
             // Set up error handler to intercept exception
             ApplicationInsightsAppender aiAppender = (ApplicationInsightsAppender)log4net.LogManager.GetRepository(callingAssembly).GetAppenders()[0];
@@ -128,7 +130,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
 
             // Set instrumentation key in Log4Net environment
             string instrumentationKey = "93d9c2b7-e633-4571-8520-d391511a1df5";
-            ApplicationInsightsAppenderTests.InitializeLog4NetAIAdapter(string.Format(@"<InstrumentationKey value=""{0}"" />", instrumentationKey));
+            ApplicationInsightsAppenderTests.InitializeLog4NetAIAdapter(string.Format(InvariantCulture, @"<InstrumentationKey value=""{0}"" />", instrumentationKey));
             Assert.AreNotEqual(instrumentationKey, this.adapterHelper.InstrumentationKey, "This test will not verify anything if the same instrumentation key is used by both");
             this.SendMessagesToMockChannel(instrumentationKey);
         }
@@ -317,7 +319,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
             }
 
             ExceptionTelemetry telemetry = (ExceptionTelemetry)this.appendableLogger.SentItems.First();
-            Assert.IsTrue(telemetry.Properties["Message"].StartsWith("custom message"));
+            Assert.IsTrue(telemetry.Properties["Message"].StartsWith("custom message", StringComparison.Ordinal));
         }
 
         internal static void InitializeLog4NetAIAdapter(string adapterComponentIdSnippet)

--- a/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
+++ b/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
@@ -124,7 +124,7 @@
 
             var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.First();
 
-            string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(typeof(ApplicationInsightsTarget), prefix: "nlog:");
+            string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "nlog:");
             Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
         }
 
@@ -250,7 +250,9 @@
 
         [TestMethod]
         [TestCategory("NLogTarget")]
+#pragma warning disable CA1707 // Identifiers should not contain underscores
         public void EventPropertyKeyNameIsAppendedWith_1_IfSameAsGlobalDiagnosticContextKeyName()
+#pragma warning restore CA1707 // Identifiers should not contain underscores
         {
             Logger aiLogger = this.CreateTargetWithGivenInstrumentationKey();
 
@@ -303,7 +305,7 @@
             }
 
             ExceptionTelemetry telemetry = (ExceptionTelemetry)this.adapterHelper.Channel.SentItems.First();
-            Assert.IsTrue(telemetry.Properties["Message"].StartsWith("custom message"));
+            Assert.IsTrue(telemetry.Properties["Message"].StartsWith("custom message", StringComparison.Ordinal));
         }
 
         [TestMethod]

--- a/test/Shared/AdapterHelper.cs
+++ b/test/Shared/AdapterHelper.cs
@@ -13,9 +13,11 @@ namespace Microsoft.ApplicationInsights.Tracing.Tests
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+    using static System.Globalization.CultureInfo;
+
     public class AdapterHelper : IDisposable
     {
-        public readonly string InstrumentationKey;
+        public string InstrumentationKey { get; }
 
 #if NET45 || NET46
         private static readonly string ApplicationInsightsConfigFilePath =
@@ -29,7 +31,7 @@ namespace Microsoft.ApplicationInsights.Tracing.Tests
         {
             this.InstrumentationKey = instrumentationKey;
 
-            string configuration = string.Format(
+            string configuration = string.Format(InvariantCulture,
                                     @"<?xml version=""1.0"" encoding=""utf-8"" ?>
                                      <ApplicationInsights xmlns=""http://schemas.microsoft.com/ApplicationInsights/2013/Settings"">
                                         <InstrumentationKey>{0}</InstrumentationKey>
@@ -76,9 +78,9 @@ namespace Microsoft.ApplicationInsights.Tracing.Tests
             GC.SuppressFinalize(this);
         }
 
-        private void Dispose(bool dispossing)
+        protected virtual void Dispose(bool disposing)
         {
-            if (dispossing)
+            if (disposing)
             {
                 this.Channel.Dispose();
 

--- a/test/Shared/ApplicationInsightsTraceListenerTests.cs
+++ b/test/Shared/ApplicationInsightsTraceListenerTests.cs
@@ -11,6 +11,8 @@
     using Microsoft.ApplicationInsights.Tracing.Tests;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+    using static System.Globalization.CultureInfo;
+
     [TestClass]
     public sealed class ApplicationInsightsTraceListenerTests : IDisposable
     {
@@ -102,7 +104,7 @@
 
                 TraceTelemetry telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.First();
 
-                string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(typeof(ApplicationInsightsTraceListener), prefix: "sd:");
+                string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "sd:");
                 Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
             }
         }
@@ -141,7 +143,7 @@
 
             TraceTelemetry telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
             Assert.AreEqual(expectedMessage, telemetry.Message);
-            Assert.AreEqual(expectedEventId.ToString(), telemetry.Properties["EventId"]);
+            Assert.AreEqual(expectedEventId.ToString(InvariantCulture), telemetry.Properties["EventId"]);
         }
 
         [TestMethod]
@@ -161,8 +163,8 @@
                 options);
 
             TraceTelemetry telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
-            Assert.AreEqual(string.Format(formatString, arg0), telemetry.Message);
-            Assert.AreEqual(expectedEventId.ToString(), telemetry.Properties["EventId"]);
+            Assert.AreEqual(string.Format(InvariantCulture, formatString, arg0), telemetry.Message);
+            Assert.AreEqual(expectedEventId.ToString(InvariantCulture), telemetry.Properties["EventId"]);
         }
 
         [TestMethod]
@@ -182,7 +184,7 @@
             
             TraceTelemetry telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
             Assert.AreEqual("(123, 123.456)", telemetry.Message);
-            Assert.AreEqual(expectedEventId.ToString(), telemetry.Properties["EventId"]);
+            Assert.AreEqual(expectedEventId.ToString(InvariantCulture), telemetry.Properties["EventId"]);
         }
 
         [TestMethod]
@@ -202,7 +204,7 @@
 
             TraceTelemetry telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
             Assert.AreEqual("(123, 123.456), https://foobar/", telemetry.Message);
-            Assert.AreEqual(expectedEventId.ToString(), telemetry.Properties["EventId"]);
+            Assert.AreEqual(expectedEventId.ToString(InvariantCulture), telemetry.Properties["EventId"]);
         }
 
 #if NET45

--- a/test/Shared/CustomTelemetryChannel.cs
+++ b/test/Shared/CustomTelemetryChannel.cs
@@ -14,14 +14,18 @@ namespace Microsoft.ApplicationInsights
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
 
-    internal class CustomTelemetryChannel : ITelemetryChannel
+    internal sealed class CustomTelemetryChannel : ITelemetryChannel
     {
         private EventWaitHandle waitHandle;
 
         public CustomTelemetryChannel()
         {
             this.waitHandle = new AutoResetEvent(false);
+#if NET45
             this.SentItems = new ITelemetry[0];
+#else
+            this.SentItems = Array.Empty<ITelemetry>();
+#endif
         }
 
         public bool? DeveloperMode { get; set; }
@@ -85,7 +89,11 @@ namespace Microsoft.ApplicationInsights
         {
             lock (this)
             {
+#if NET45
                 this.SentItems = new ITelemetry[0];
+#else
+                this.SentItems = Array.Empty<ITelemetry>();
+#endif
             }
 
             return this;


### PR DESCRIPTION
CA1307 Use StringComparison.Ordinal for StartsWith
CA1063 Seal classes with trivial Dispose methods
CA1305 Use InvariantCulture for ToString and string.Format
CA1309 Use ordinal comparison
CA1507 Use nameof
CA1801 Review unused parameters
CA1823 Remove unused fields
CA1825 Avoid zero length array allocations
CA2007 Call ConfigureAwait