### PR TITLE
re-enable symbols packages

### DIFF
--- a/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
+++ b/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <IncludeSymbols>False</IncludeSymbols>
+    <IncludeSymbols>True</IncludeSymbols>
     <PackageId>Microsoft.ApplicationInsights.DiagnosticSourceListener</PackageId>
     <Title>Application Insights DiagnosticSourceListener</Title>
     <Description>Application Insights DiagnosticSourceListener allows forwarding events from DiagnosticSource to Application Insights. Application Insights will collect your logs from multiple sources and provide rich powerful search capabilities. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>

--- a/src/EtwCollector/EtwCollector.csproj
+++ b/src/EtwCollector/EtwCollector.csproj
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <IncludeSymbols>False</IncludeSymbols>
+    <IncludeSymbols>True</IncludeSymbols>
     <PackageId>Microsoft.ApplicationInsights.EtwCollector</PackageId>
     <Title>Application Insights EtwCollector</Title>
     <Description>Application Insights EtwCollector allows sending data from Event Tracing for Windows (ETW) to Application Insights. Application Insights will collect your logs from multiple sources and provide rich powerful search capabilities. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156.</Description>

--- a/src/EventSourceListener/EventSourceListener.csproj
+++ b/src/EventSourceListener/EventSourceListener.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <IncludeSymbols>False</IncludeSymbols>
+    <IncludeSymbols>True</IncludeSymbols>
     <PackageId>Microsoft.ApplicationInsights.EventSourceListener</PackageId>
     <Title>Application Insights EventSourceListener</Title>
     <Description>Application Insights EventSourceListener allows sending data from EventSource events to Application Insights. Application Insights will collect your logs from multiple sources and provide rich powerful search capabilities. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>

--- a/src/Log4NetAppender/Log4NetAppender.csproj
+++ b/src/Log4NetAppender/Log4NetAppender.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <IncludeSymbols>False</IncludeSymbols>
+    <IncludeSymbols>True</IncludeSymbols>
     <PackageId>Microsoft.ApplicationInsights.Log4NetAppender</PackageId>
     <Title>Application Insights Log4Net Appender</Title>
     <Description>Application Insights Log4Net Appender is a customer appender allowing you to send Log4Net log messages to Application Insights. Application Insights will collect your logs from multiple sources and provide rich powerful search capabilities. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>

--- a/src/NLogTarget/NLogTarget.csproj
+++ b/src/NLogTarget/NLogTarget.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <IncludeSymbols>False</IncludeSymbols>
+    <IncludeSymbols>True</IncludeSymbols>
     <PackageId>Microsoft.ApplicationInsights.NLogTarget</PackageId>
     <Title>Application Insights NLog Target</Title>
     <Description>Application Insights NLog Target is a custom target allowing you to send NLog log messages to Application Insights. Application Insights will collect your logs from multiple sources and provide rich powerful search capabilities. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>

--- a/src/TraceListener/TraceListener.csproj
+++ b/src/TraceListener/TraceListener.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <IncludeSymbols>False</IncludeSymbols>
+    <IncludeSymbols>True</IncludeSymbols>
     <PackageId>Microsoft.ApplicationInsights.TraceListener</PackageId>
     <Title>Application Insights TraceListener</Title>
     <Description>Application Insights Trace Listener is a custom TraceListener allowing you to send trace log messages to Application Insights. Application Insights will collect your logs from multiple sources and provide rich powerful search capabilities. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>


### PR DESCRIPTION
Symbols packages had to be disabled due to a bug in our build infrastructure.
That bug has been resolved and we are re-enabling this.