### PR TITLE
NLog ApplicationInsightsTarget - Add support for using GDC for InstrumentationKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog 
 
-
+### Version 2.6.5
+- [NLog can perform Layout of InstrumentationKey](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/203)
 
 ### Version 2.6.4
 - [Log4Net new supports NetStandard 1.3!](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/167)

--- a/src/NLogTarget/ApplicationInsightsTarget.cs
+++ b/src/NLogTarget/ApplicationInsightsTarget.cs
@@ -30,6 +30,7 @@ namespace Microsoft.ApplicationInsights.NLogTarget
     {
         private TelemetryClient telemetryClient;
         private DateTime lastLogEventTime;
+        private NLog.Layouts.Layout instrumentationKeyLayout = string.Empty;
 
         /// <summary>
         /// Initializers a new instance of ApplicationInsightsTarget type.
@@ -42,7 +43,11 @@ namespace Microsoft.ApplicationInsights.NLogTarget
         /// <summary>
         /// Gets or sets the Application Insights instrumentationKey for your application. 
         /// </summary>
-        public string InstrumentationKey { get; set; }
+        public string InstrumentationKey
+        {
+            get => (this.instrumentationKeyLayout as NLog.Layouts.SimpleLayout)?.Text ?? null;
+            set => this.instrumentationKeyLayout = value ?? string.Empty;
+        }
 
         /// <summary>
         /// Gets the array of custom attributes to be passed into the logevent context
@@ -109,9 +114,11 @@ namespace Microsoft.ApplicationInsights.NLogTarget
         {
             base.InitializeTarget();
             this.telemetryClient = new TelemetryClient();
-            if (!string.IsNullOrEmpty(this.InstrumentationKey))
+
+            string instrumentationKey = this.instrumentationKeyLayout.Render(LogEventInfo.CreateNullEvent());
+            if (!string.IsNullOrWhiteSpace(instrumentationKey))
             {
-                this.telemetryClient.Context.InstrumentationKey = this.InstrumentationKey;
+                this.telemetryClient.Context.InstrumentationKey = instrumentationKey;
             }
 
             this.telemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("nlog:");

--- a/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
+++ b/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
@@ -95,6 +95,19 @@
 
         [TestMethod]
         [TestCategory("NLogTarget")]
+        public void InstrumentationKeyIsReadFromLayout()
+        {
+            string instrumentationKey = "F8474271-D231-45B6-8DD4-D344C309AE69";
+
+            var gdcKey = Guid.NewGuid().ToString();
+            NLog.GlobalDiagnosticsContext.Set(gdcKey, instrumentationKey);
+
+            Logger aiLogger = this.CreateTargetWithGivenInstrumentationKey($"${{gdc:item={gdcKey}}}");
+            this.VerifyMessagesInMockChannel(aiLogger, instrumentationKey);
+        }
+
+        [TestMethod]
+        [TestCategory("NLogTarget")]
         public void TraceAreEnqueuedInChannelAndContainAllProperties()
         {
             string instrumentationKey = "F8474271-D231-45B6-8DD4-D344C309AE69";


### PR DESCRIPTION
Resolves #201

Normally NLog properties are just added like this:

`public NLog.Layouts.Layout InstrumentationKey { get; set; }`

But because it would be a breaking change, then this PR is a little convoluted.