### PR TITLE
Disable Microsoft-ApplicationInsights-Data EventSource by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Version 2.7.1
 - [NLog can perform Layout of InstrumentationKey](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/203)
 - Upgrade `System.Diagnostics.DiagnosticSource` to version 4.5.0
+- [Event Source telemetry module: Microsoft-ApplicationInsights-Data id disabled by default to work around CLR bug](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/206)
 
 ### Version 2.6.4
 - [Log4Net new supports NetStandard 1.3!](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/167)

--- a/src/EventSourceListener/EventSourceListeningRequestBase.cs
+++ b/src/EventSourceListener/EventSourceListeningRequestBase.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether allows wildcards in <see cref="Name" />.
+        /// Gets or sets a value indicating whether the value of the <see cref="Name"/> property should match the name of an EventSource exactly, or should the value be treated as EventSource name prefix.
         /// </summary>
         public bool PrefixMatch { get; set; }
 

--- a/test/EventSourceListener.netcoreapp10.Tests/EventSourceTelemetryModuleTests.cs
+++ b/test/EventSourceListener.netcoreapp10.Tests/EventSourceTelemetryModuleTests.cs
@@ -411,6 +411,32 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Tests
             }
         }
 
+        [TestMethod]
+        [TestCategory("EventSourceListener")]
+        public void DisablesAppInsightsDataByDefault()
+        {
+            using (var module = new EventSourceTelemetryModule())
+            {
+                module.Initialize(GetTestTelemetryConfiguration());
+
+                Assert.AreEqual(1, module.DisabledSources.Count);
+                Assert.AreEqual(new DisableEventSourceRequest { Name = "Microsoft-ApplicationInsights-Data" }, module.DisabledSources[0]);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("EventSourceListener")]
+        public void DoesNotDisableAppInsightsDataIfExplicitlyEnabled()
+        {
+            using (var module = new EventSourceTelemetryModule())
+            {
+                module.Sources.Add(new EventSourceListeningRequest { Name = "Microsoft-ApplicationInsights-Data" });
+                module.Initialize(GetTestTelemetryConfiguration());
+
+                Assert.AreEqual(0, module.DisabledSources.Count);
+            }
+        }
+
         private Task PerformActivityAsync(int requestId)
         {
             return Task.Run(async () =>


### PR DESCRIPTION
Because of https://github.com/dotnet/coreclr/issues/14434 using EventSourceTelemetryModule might cause an infinite loop. This change prevents it from happening in the case of Micrsoft-ApplicationInsights-Data EventSource. 

The approach has been discussed with @SergeyKanzhelev and @mmilirud 