### PR TITLE
[WIP] bump version to 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog 
 
+### Version 2.8.0
+- NLog will support new Context.GlobalProperties field added in BaseSDK 2.8.0 (TODO: LINK)
+
 ### Version 2.7.2
 - [NLog can perform Layout of InstrumentationKey](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/203)
 - Upgrade `System.Diagnostics.DiagnosticSource` to version 4.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog 
 
-### Version 2.8.0
-- NLog will support new Context.GlobalProperties field added in BaseSDK 2.8.0 (TODO: LINK)
+### Version 2.8.1
+- NLog will support new Context.GlobalProperties field added in [BaseSDK 2.8.1](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/820)
 
 ### Version 2.7.2
 - [NLog can perform Layout of InstrumentationKey](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/203)

--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -7,7 +7,7 @@
     -->
     <SemanticVersionMajor>2</SemanticVersionMajor>
     <SemanticVersionMinor>8</SemanticVersionMinor>
-    <SemanticVersionPatch>0</SemanticVersionPatch>
+    <SemanticVersionPatch>1</SemanticVersionPatch>
     <PreReleaseMilestone></PreReleaseMilestone>
     <!-- 
       Date when Semantic Version was changed. 

--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -6,14 +6,14 @@
       Update for every public release. 
     -->
     <SemanticVersionMajor>2</SemanticVersionMajor>
-    <SemanticVersionMinor>7</SemanticVersionMinor>
-    <SemanticVersionPatch>2</SemanticVersionPatch>
+    <SemanticVersionMinor>8</SemanticVersionMinor>
+    <SemanticVersionPatch>0</SemanticVersionPatch>
     <PreReleaseMilestone></PreReleaseMilestone>
     <!-- 
       Date when Semantic Version was changed. 
       Update for every public release.
     -->
-    <SemanticVersionDate>2018-05-21</SemanticVersionDate>
+    <SemanticVersionDate>2018-08-01</SemanticVersionDate>
     
     <PreReleaseVersionFileName>.PreReleaseVersion</PreReleaseVersionFileName>
     <PreReleaseVersionFilePath>$(MSBuildThisFileDirectory)$(PreReleaseVersionFileName)</PreReleaseVersionFilePath>

--- a/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
+++ b/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
@@ -38,7 +38,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
+++ b/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
@@ -38,7 +38,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/EtwCollector/EtwCollector.csproj
+++ b/src/EtwCollector/EtwCollector.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.41" />
   </ItemGroup>
 

--- a/src/EtwCollector/EtwCollector.csproj
+++ b/src/EtwCollector/EtwCollector.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.41" />
   </ItemGroup>
 

--- a/src/EventSourceListener/EventSourceListener.csproj
+++ b/src/EventSourceListener/EventSourceListener.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/EventSourceListener/EventSourceListener.csproj
+++ b/src/EventSourceListener/EventSourceListener.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Log4NetAppender/ApplicationInsightsAppender.cs
+++ b/src/Log4NetAppender/ApplicationInsightsAppender.cs
@@ -100,20 +100,14 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender
             }
         }
 
-        private static void BuildCustomProperties(LoggingEvent loggingEvent, ITelemetry trace)
+        private static void PopulateTelemetryProperties(LoggingEvent loggingEvent, ITelemetry telemetry)
         {
-            trace.Timestamp = loggingEvent.TimeStamp;
+            telemetry.Timestamp = loggingEvent.TimeStamp;
+        }
 
-            IDictionary<string, string> metaData;
-            
-            if (trace is ExceptionTelemetry)
-            {
-                metaData = ((ExceptionTelemetry)trace).Properties;
-            }
-            else
-            {
-                metaData = ((TraceTelemetry)trace).Properties;
-            }
+        private static void PopulateTelemetryPropertyBag(LoggingEvent loggingEvent, ISupportProperties telemetryItem)
+        {
+            IDictionary<string, string> metaData = telemetryItem.Properties;
 
             AddLoggingEventProperty("LoggerName", loggingEvent.LoggerName, metaData);
             AddLoggingEventProperty("ThreadName", loggingEvent.ThreadName, metaData);
@@ -197,7 +191,8 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender
                     exceptionTelemetry.Properties.Add("Message", message);
                 }
 
-                BuildCustomProperties(loggingEvent, exceptionTelemetry);
+                PopulateTelemetryProperties(loggingEvent, exceptionTelemetry);
+                PopulateTelemetryPropertyBag(loggingEvent, exceptionTelemetry);
                 this.telemetryClient.Track(exceptionTelemetry);
             }
             catch (ArgumentNullException exception)
@@ -218,7 +213,8 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender
                     SeverityLevel = GetSeverityLevel(loggingEvent.Level)
                 };
 
-                BuildCustomProperties(loggingEvent, trace);
+                PopulateTelemetryProperties(loggingEvent, trace);
+                PopulateTelemetryPropertyBag(loggingEvent, trace);
                 this.telemetryClient.Track(trace);
             }
             catch (ArgumentNullException exception)

--- a/src/Log4NetAppender/Log4NetAppender.csproj
+++ b/src/Log4NetAppender/Log4NetAppender.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/Log4NetAppender/Log4NetAppender.csproj
+++ b/src/Log4NetAppender/Log4NetAppender.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/NLogTarget/NLogTarget.csproj
+++ b/src/NLogTarget/NLogTarget.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/NLogTarget/NLogTarget.csproj
+++ b/src/NLogTarget/NLogTarget.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/TraceListener/TraceListener.csproj
+++ b/src/TraceListener/TraceListener.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/src/TraceListener/TraceListener.csproj
+++ b/src/TraceListener/TraceListener.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceListener.netcoreapp1.Tests.csproj
+++ b/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceListener.netcoreapp1.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceListener.netcoreapp1.Tests.csproj
+++ b/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceListener.netcoreapp1.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EtwCollector.Net451.Tests/EtwCollector.Net451.Tests.csproj
+++ b/test/EtwCollector.Net451.Tests/EtwCollector.Net451.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.41" />
     <ProjectReference Include="..\..\src\EtwCollector\EtwCollector.csproj" />
     <Reference Include="System.Net.Http" />

--- a/test/EtwCollector.Net451.Tests/EtwCollector.Net451.Tests.csproj
+++ b/test/EtwCollector.Net451.Tests/EtwCollector.Net451.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.41" />
     <ProjectReference Include="..\..\src\EtwCollector\EtwCollector.csproj" />
     <Reference Include="System.Net.Http" />

--- a/test/EventSourceListener.netcoreapp10.Tests/EventSourceListener.netcoreapp10.Tests.csproj
+++ b/test/EventSourceListener.netcoreapp10.Tests/EventSourceListener.netcoreapp10.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EventSourceListener.netcoreapp10.Tests/EventSourceListener.netcoreapp10.Tests.csproj
+++ b/test/EventSourceListener.netcoreapp10.Tests/EventSourceListener.netcoreapp10.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
+++ b/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
             Assert.AreEqual(1, sentItems.Length);
 
             var telemetry = (TraceTelemetry)sentItems[0];
-            Assert.AreEqual("Value1", telemetry.Context.Properties["CustomProperty1"]);
+            Assert.AreEqual("Value1", telemetry.Properties["CustomProperty1"]);
         }
 
         [TestMethod]
@@ -207,7 +207,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
 
             var telemetry = (TraceTelemetry)sentItems[0];
 
-            foreach (var key in telemetry.Context.Properties.Keys)
+            foreach (var key in telemetry.Properties.Keys) 
             {
                 Assert.IsFalse(key.StartsWith("log4net", StringComparison.OrdinalIgnoreCase));
             }

--- a/test/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
+++ b/test/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
     <PackageReference Include="log4net" Version="2.0.6" />
     <ProjectReference Include="..\..\src\Log4NetAppender\Log4NetAppender.csproj" />
     <Reference Include="System.Net.Http" />

--- a/test/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
+++ b/test/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="log4net" Version="2.0.6" />
     <ProjectReference Include="..\..\src\Log4NetAppender\Log4NetAppender.csproj" />
     <Reference Include="System.Net.Http" />

--- a/test/Log4NetAppender.NetCoreApp10.Tests/Log4NetAppender.NetCoreApp10.Tests.csproj
+++ b/test/Log4NetAppender.NetCoreApp10.Tests/Log4NetAppender.NetCoreApp10.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <ProjectReference Include="..\..\src\Log4NetAppender\Log4NetAppender.csproj" />
   </ItemGroup>

--- a/test/Log4NetAppender.NetCoreApp10.Tests/Log4NetAppender.NetCoreApp10.Tests.csproj
+++ b/test/Log4NetAppender.NetCoreApp10.Tests/Log4NetAppender.NetCoreApp10.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <ProjectReference Include="..\..\src\Log4NetAppender\Log4NetAppender.csproj" />
   </ItemGroup>

--- a/test/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
+++ b/test/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
     <PackageReference Include="NLog" Version="4.4.12" />
     <ProjectReference Include="..\..\src\NLogTarget\NLogTarget.csproj" />
     <Reference Include="System.Net.Http" />

--- a/test/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
+++ b/test/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="NLog" Version="4.4.12" />
     <ProjectReference Include="..\..\src\NLogTarget\NLogTarget.csproj" />
     <Reference Include="System.Net.Http" />

--- a/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
+++ b/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
@@ -227,9 +227,13 @@
             var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
             Assert.IsNotNull(telemetry, "Didn't get the log event from the channel");
 
-            Assert.AreEqual("Value", telemetry.Context.Properties["Name"]);
-        }
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.AreEqual("Value", telemetry.Context.Properties["Name"]); // [BACKWARDS COMPAT] context properties are set
+#pragma warning restore CS0618 // Type or member is obsolete
 
+
+            Assert.AreEqual("Value", telemetry.Properties["Name"]); // local properties are set
+        }
 
         [TestMethod]
         [TestCategory("NLogTarget")]
@@ -243,9 +247,15 @@
             aiLogger.Debug("Message");
 
             var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
-            Assert.AreEqual("global_value", telemetry.Context.Properties["global_prop"]);
-        }
 
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.AreEqual("global_value", telemetry.Context.Properties["global_prop"]); // [BACKWARDS COMPAT] context properties are set
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.AreEqual("global_value", telemetry.Context.GlobalProperties["global_prop"]); // global properties are set
+            Assert.AreEqual("global_value", telemetry.Properties["global_prop"]); // global properties are copied to local properties
+        }
+        
         [TestMethod]
         [TestCategory("NLogTarget")]
         public void GlobalDiagnosticContextPropertiesSupplementEventProperties()
@@ -261,8 +271,14 @@
             aiLogger.Log(eventInfo);
 
             var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
-            Assert.AreEqual("global_value", telemetry.Context.Properties["global_prop"]);
-            Assert.AreEqual("Value", telemetry.Context.Properties["Name"]);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.AreEqual("global_value", telemetry.Context.Properties["global_prop"]);  // [BACKWARDS COMPAT] context properties are set
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.AreEqual("global_value", telemetry.Context.GlobalProperties["global_prop"]); // global properties are set.
+            Assert.AreEqual("global_value", telemetry.Properties["global_prop"]); // global properties are copied to local properties
+            Assert.AreEqual("Value", telemetry.Properties["Name"]); // local properties are set
         }
 
         [TestMethod]
@@ -281,9 +297,16 @@
             aiLogger.Log(eventInfo);
 
             var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
-            Assert.IsTrue(telemetry.Context.Properties.ContainsKey("Name_1"), "Key name altered");
-            Assert.AreEqual("Global Value", telemetry.Context.Properties["Name"]);
-            Assert.AreEqual("Value", telemetry.Context.Properties["Name_1"]);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.IsTrue(telemetry.Context.Properties.ContainsKey("Name")); // [BACKWARDS COMPAT] // global properties are set on context properties
+            Assert.AreEqual("Global Value", telemetry.Context.GlobalProperties["Name"]); // [BACKWARDS COMPAT] // global properties are set on context properties
+            Assert.IsTrue(telemetry.Context.Properties.ContainsKey("Name_1"), "Key name altered"); // [BACKWARDS COMPAT] local properties are set on context properties with "_1"
+            Assert.AreEqual("Value", telemetry.Context.Properties["Name_1"]); // [BACKWARDS COMPAT] local properties are set on context properties with "_1"
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.AreEqual("Global Value", telemetry.Context.GlobalProperties["Name"]); // global properties are set.
+            Assert.AreEqual("Value", telemetry.Properties["Name_1"]); // local properties are set with "_1"
         }
 
         [TestMethod]

--- a/test/NLogTarget.NetCoreApp10.Tests/NLogTarget.NetCoreApp10.Tests.csproj
+++ b/test/NLogTarget.NetCoreApp10.Tests/NLogTarget.NetCoreApp10.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="NLog" Version="4.5.0" />
     <ProjectReference Include="..\..\src\NLogTarget\NLogTarget.csproj" />
   </ItemGroup>

--- a/test/NLogTarget.NetCoreApp10.Tests/NLogTarget.NetCoreApp10.Tests.csproj
+++ b/test/NLogTarget.NetCoreApp10.Tests/NLogTarget.NetCoreApp10.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
     <PackageReference Include="NLog" Version="4.5.0" />
     <ProjectReference Include="..\..\src\NLogTarget\NLogTarget.csproj" />
   </ItemGroup>

--- a/test/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
+++ b/test/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
     <PackageReference Include="log4net" Version="2.0.5" />
     <ProjectReference Include="..\..\src\TraceListener\TraceListener.csproj" />
     <Reference Include="System.Net.Http" />

--- a/test/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
+++ b/test/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="log4net" Version="2.0.5" />
     <ProjectReference Include="..\..\src\TraceListener\TraceListener.csproj" />
     <Reference Include="System.Net.Http" />

--- a/test/TraceListener.netcoreapp10.Tests/TraceListener.netcoreapp10.Tests.csproj
+++ b/test/TraceListener.netcoreapp10.Tests/TraceListener.netcoreapp10.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
 

--- a/test/TraceListener.netcoreapp10.Tests/TraceListener.netcoreapp10.Tests.csproj
+++ b/test/TraceListener.netcoreapp10.Tests/TraceListener.netcoreapp10.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
 

--- a/test/Xdt.Tests/Xdt.Tests.csproj
+++ b/test/Xdt.Tests/Xdt.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/test/Xdt.Tests/Xdt.Tests.csproj
+++ b/test/Xdt.Tests/Xdt.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
test started failing because `Context.Properties` was marked Obsolete.

- Log4Net was incorrectly using `Context.Properties` instead of `telemetry.Properties`. Fixed.
- NLog had a concept of Global Properties. Changed to use `Context.GlobalProperties`.
- Fixed some unnecessary type casting


See also:
https://github.com/Microsoft/ApplicationInsights-dotnet/pull/839
https://github.com/Microsoft/ApplicationInsights-dotnet/issues/820
https://github.com/Microsoft/ApplicationInsights-dotnet/issues/923
