### PR TITLE
2.8.1: fix Context.Properties tests

### DIFF
--- a/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
+++ b/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
             Assert.AreEqual(1, sentItems.Length);
 
             var telemetry = (TraceTelemetry)sentItems[0];
-            Assert.AreEqual("Value1", telemetry.Context.Properties["CustomProperty1"]);
+            Assert.AreEqual("Value1", telemetry.Properties["CustomProperty1"]);
         }
 
         [TestMethod]
@@ -207,7 +207,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
 
             var telemetry = (TraceTelemetry)sentItems[0];
 
-            foreach (var key in telemetry.Context.Properties.Keys)
+            foreach (var key in telemetry.Properties.Keys)
             {
                 Assert.IsFalse(key.StartsWith("log4net", StringComparison.OrdinalIgnoreCase));
             }

--- a/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
+++ b/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
@@ -227,11 +227,15 @@
             var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
             Assert.IsNotNull(telemetry, "Didn't get the log event from the channel");
 
-            Assert.AreEqual("Value", telemetry.Context.Properties["Name"]);
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.AreEqual("Value", telemetry.Context.Properties["Name"]); // [BACKWARDS COMPAT] context properties are set
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            // TODO: Implement Context.GlobalProperties
         }
 
 
-        [TestMethod]
+    [TestMethod]
         [TestCategory("NLogTarget")]
         public void GlobalDiagnosticContextPropertiesAreAddedToProperties()
         {
@@ -243,7 +247,12 @@
             aiLogger.Debug("Message");
 
             var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
-            Assert.AreEqual("global_value", telemetry.Context.Properties["global_prop"]);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.AreEqual("global_value", telemetry.Context.Properties["global_prop"]); // [BACKWARDS COMPAT] context properties are set
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            // TODO: Implement Context.GlobalProperties
         }
 
         [TestMethod]
@@ -261,8 +270,13 @@
             aiLogger.Log(eventInfo);
 
             var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
-            Assert.AreEqual("global_value", telemetry.Context.Properties["global_prop"]);
-            Assert.AreEqual("Value", telemetry.Context.Properties["Name"]);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.AreEqual("global_value", telemetry.Context.Properties["global_prop"]); // [BACKWARDS COMPAT] context properties are set
+            Assert.AreEqual("Value", telemetry.Context.Properties["Name"]); // [BACKWARDS COMPAT] local properties are set
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            // TODO: Implement Context.GlobalProperties
         }
 
         [TestMethod]
@@ -281,9 +295,15 @@
             aiLogger.Log(eventInfo);
 
             var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
-            Assert.IsTrue(telemetry.Context.Properties.ContainsKey("Name_1"), "Key name altered");
-            Assert.AreEqual("Global Value", telemetry.Context.Properties["Name"]);
-            Assert.AreEqual("Value", telemetry.Context.Properties["Name_1"]);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.IsTrue(telemetry.Context.Properties.ContainsKey("Name")); // [BACKWARDS COMPAT] // global properties are set on context properties
+            Assert.AreEqual("Global Value", telemetry.Context.Properties["Name"]); // [BACKWARDS COMPAT] // global properties are set on context properties
+            Assert.IsTrue(telemetry.Context.Properties.ContainsKey("Name_1"), "Key name altered"); // [BACKWARDS COMPAT] local properties are set on context properties with "_1"
+            Assert.AreEqual("Value", telemetry.Context.Properties["Name_1"]); // [BACKWARDS COMPAT] local properties are set on context properties with "_1"
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            // TODO: Implement Context.GlobalProperties
         }
 
         [TestMethod]


### PR DESCRIPTION
- removed test reference to `Context.Properties` where it doesn't make sense. Should check local properties using `telemetry.Properties`. This behavior is not changed.
- marked other `Context.Properties` uses to not fail the tests. [Backwards Compat]
- todo: in a future PR, should implement `Context.GlobalProperties`

