### PR TITLE
UpdateLog4Net to >=2.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog 
 
+### Version 2.9
+- Update log4net reference to [2.0.7](https://www.nuget.org/packages/log4net/2.0.7)
+
 ### Version 2.8.1
 - Update BaseSdk reference to 2.8.1. See [release notes](https://github.com/Microsoft/ApplicationInsights-dotnet/releases) for more information.
 

--- a/src/Log4NetAppender/Log4NetAppender.csproj
+++ b/src/Log4NetAppender/Log4NetAppender.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
-    <PackageReference Include="log4net" Version="2.0.6" />
+    <PackageReference Include="log4net" Version="2.0.7" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
+++ b/test/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
-    <PackageReference Include="log4net" Version="2.0.6" />
+    <PackageReference Include="log4net" Version="2.0.7" />
     <ProjectReference Include="..\..\src\Log4NetAppender\Log4NetAppender.csproj" />
     <Reference Include="System.Net.Http" />
 


### PR DESCRIPTION
[Log4Net 2.0.6](https://www.nuget.org/packages/log4net/2.0.6) does not have dependencies specified for .NET 4.6 and it makes Visual Studio Package Manager installing all .NET Standard dependencies instead. This leads to a conflict between .Net and .Net Standard libraries and compilation fails to resolve which of the conflicting assemblies to use.

Starting [Log4net 2.0.7](https://www.nuget.org/packages/log4net/2.0.7), there is an explicit empty list of dependencies for .NET 4.6 and Package Manager does not install any dependencies.

Given that 2.0.6 is downloaded ~190 000 times and 2.0.7 + 2.0.8 are at 8 000 000 downloads, I assume it's safe to update the references from 2.0.6 to 2.0.7.