### PR TITLE
ILogger implementation for ApplicationInsights

### DIFF
--- a/Logging.sln
+++ b/Logging.sln
@@ -63,6 +63,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLogTarget.NetCoreApp10.Tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Log4NetAppender.NetCoreApp10.Tests", "test\Log4NetAppender.NetCoreApp10.Tests\Log4NetAppender.NetCoreApp10.Tests.csproj", "{F74826DB-53B1-4588-BD02-4DD25DCBF292}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILogger", "src\ILogger\ILogger.csproj", "{7D942802-E85E-4C3C-B97E-67A3867B7CBA}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\CommonTestShared\CommonTestShared.projitems*{3b9ab7fa-562d-4e4e-86e3-3348426bc0d9}*SharedItemsImports = 13
@@ -225,6 +227,14 @@ Global
 		{F74826DB-53B1-4588-BD02-4DD25DCBF292}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F74826DB-53B1-4588-BD02-4DD25DCBF292}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{F74826DB-53B1-4588-BD02-4DD25DCBF292}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{7D942802-E85E-4C3C-B97E-67A3867B7CBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D942802-E85E-4C3C-B97E-67A3867B7CBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D942802-E85E-4C3C-B97E-67A3867B7CBA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{7D942802-E85E-4C3C-B97E-67A3867B7CBA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{7D942802-E85E-4C3C-B97E-67A3867B7CBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D942802-E85E-4C3C-B97E-67A3867B7CBA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D942802-E85E-4C3C-B97E-67A3867B7CBA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{7D942802-E85E-4C3C-B97E-67A3867B7CBA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -251,6 +261,7 @@ Global
 		{11E4A92F-154E-450B-8508-437C28744BC2} = {2FCC45B3-D820-405D-87FA-467C96465BB1}
 		{B24CB3C6-A3A0-4190-97E4-E847C7B1A691} = {2FCC45B3-D820-405D-87FA-467C96465BB1}
 		{F74826DB-53B1-4588-BD02-4DD25DCBF292} = {2FCC45B3-D820-405D-87FA-467C96465BB1}
+		{7D942802-E85E-4C3C-B97E-67A3867B7CBA} = {EE933574-C82B-4E59-A0D1-05328197B937}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AC8888B1-0E98-49D7-BE15-EB97A6261C0D}

--- a/Logging.sln
+++ b/Logging.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28315.86
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{EE933574-C82B-4E59-A0D1-05328197B937}"
 EndProject
@@ -63,7 +63,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLogTarget.NetCoreApp10.Tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Log4NetAppender.NetCoreApp10.Tests", "test\Log4NetAppender.NetCoreApp10.Tests\Log4NetAppender.NetCoreApp10.Tests.csproj", "{F74826DB-53B1-4588-BD02-4DD25DCBF292}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILogger", "src\ILogger\ILogger.csproj", "{7D942802-E85E-4C3C-B97E-67A3867B7CBA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILogger", "src\ILogger\ILogger.csproj", "{7D942802-E85E-4C3C-B97E-67A3867B7CBA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILogger.NetStandard.Tests", "test\ILogger.NetStandard.Tests\ILogger.NetStandard.Tests.csproj", "{4C1B862F-8F19-4D0F-834D-694DDE0438AE}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -235,6 +237,14 @@ Global
 		{7D942802-E85E-4C3C-B97E-67A3867B7CBA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7D942802-E85E-4C3C-B97E-67A3867B7CBA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{7D942802-E85E-4C3C-B97E-67A3867B7CBA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{4C1B862F-8F19-4D0F-834D-694DDE0438AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C1B862F-8F19-4D0F-834D-694DDE0438AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C1B862F-8F19-4D0F-834D-694DDE0438AE}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{4C1B862F-8F19-4D0F-834D-694DDE0438AE}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{4C1B862F-8F19-4D0F-834D-694DDE0438AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C1B862F-8F19-4D0F-834D-694DDE0438AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C1B862F-8F19-4D0F-834D-694DDE0438AE}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{4C1B862F-8F19-4D0F-834D-694DDE0438AE}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -262,6 +272,7 @@ Global
 		{B24CB3C6-A3A0-4190-97E4-E847C7B1A691} = {2FCC45B3-D820-405D-87FA-467C96465BB1}
 		{F74826DB-53B1-4588-BD02-4DD25DCBF292} = {2FCC45B3-D820-405D-87FA-467C96465BB1}
 		{7D942802-E85E-4C3C-B97E-67A3867B7CBA} = {EE933574-C82B-4E59-A0D1-05328197B937}
+		{4C1B862F-8F19-4D0F-834D-694DDE0438AE} = {2FCC45B3-D820-405D-87FA-467C96465BB1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AC8888B1-0E98-49D7-BE15-EB97A6261C0D}

--- a/src/ILogger/ApplicationInsightsLogger.cs
+++ b/src/ILogger/ApplicationInsightsLogger.cs
@@ -1,0 +1,203 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ApplicationInsightsLogger.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation. 
+// All rights reserved.  2013
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.Extensions.Logging.ApplicationInsights
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Text;
+    using Microsoft.ApplicationInsights;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Implementation;
+
+    /// <summary>
+    /// Application insights logger implementation for <see cref="ILogger"/>.
+    /// </summary>
+    /// <seealso cref="Microsoft.Extensions.Logging.ILogger" />
+    public class ApplicationInsightsLogger : ILogger, IDisposable
+    {
+        private readonly string categoryName;
+        private readonly TelemetryClient telemetryClient;
+        private readonly ApplicationInsightsLoggerOptions applicationInsightsLoggerOptions;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ApplicationInsightsLogger"/>
+        /// </summary>
+        public ApplicationInsightsLogger(
+            string categoryName,
+            TelemetryClient telemetryClient,
+            ApplicationInsightsLoggerOptions applicationInsightsLoggerOptions)
+        {
+            this.categoryName = categoryName;
+            this.telemetryClient = telemetryClient;
+            this.telemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("il:");
+            this.applicationInsightsLoggerOptions = applicationInsightsLoggerOptions ?? throw new ArgumentNullException(nameof(applicationInsightsLoggerOptions));
+        }
+
+        /// <summary>
+        /// Gets or sets the external scope provider.
+        /// </summary>
+        internal IExternalScopeProvider ExternalScopeProvider { get; set; }
+
+        /// <summary>
+        /// Begins a logical operation scope.
+        /// </summary>
+        /// <typeparam name="TState">Current state.</typeparam>
+        /// <param name="state">The identifier for the scope.</param>
+        /// <returns>
+        /// An IDisposable that ends the logical operation scope on dispose.
+        /// </returns>
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return this.ExternalScopeProvider != null ? this.ExternalScopeProvider.Push(state) : NullScope.Instance;
+        }
+
+        /// <summary>
+        /// Checks if the given <paramref name="logLevel" /> is enabled.
+        /// </summary>
+        /// <param name="logLevel">level to be checked.</param>
+        /// <returns>
+        ///   <c>true</c> if enabled.
+        /// </returns>
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return this.telemetryClient.IsEnabled();
+        }
+
+        /// <summary>
+        /// Writes a log entry.
+        /// </summary>
+        /// <typeparam name="TState">State being passed along.</typeparam>
+        /// <param name="logLevel">Entry will be written on this level.</param>
+        /// <param name="eventId">Id of the event.</param>
+        /// <param name="state">The entry to be written. Can be also an object.</param>
+        /// <param name="exception">The exception related to this entry.</param>
+        /// <param name="formatter">Function to create a <c>string</c> message of the <paramref name="state" /> and <paramref name="exception" />.</param>
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (this.IsEnabled(logLevel))
+            {
+                if (exception == null || this.applicationInsightsLoggerOptions?.TrackExceptionsAsExceptionTelemetry == false)
+                {
+                    TraceTelemetry traceTelemetry = new TraceTelemetry(formatter(state, exception), this.GetSeverityLevel(logLevel));
+                    this.PopulateTelemetry(traceTelemetry, state, eventId);
+                    this.telemetryClient.TrackTrace(traceTelemetry);
+                }
+                else
+                {
+                    ExceptionTelemetry exceptionTelemetry = new ExceptionTelemetry(exception)
+                    {
+                        Message = formatter(state, exception),
+                        SeverityLevel = this.GetSeverityLevel(logLevel),
+                    };
+                    exceptionTelemetry.Context.Properties["Exception"] = exception.ToString();
+                    this.PopulateTelemetry(exceptionTelemetry, state, eventId);
+                    this.telemetryClient.TrackException(exceptionTelemetry);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+
+        private void PopulateTelemetry<TState>(ITelemetry telemetry, TState state, EventId eventId)
+        {
+            IReadOnlyList<KeyValuePair<string, object>> stateDictionary = state as IReadOnlyList<KeyValuePair<string, object>>;
+            IDictionary<string, string> dict = telemetry.Context.Properties;
+            dict["CategoryName"] = this.categoryName;
+
+            if (this.applicationInsightsLoggerOptions?.IncludeEventId ?? false)
+            {
+                if (eventId.Id != 0)
+                {
+                    dict["EventId"] = eventId.Id.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                }
+
+                if (!string.IsNullOrEmpty(eventId.Name))
+                {
+                    dict["EventName"] = eventId.Name;
+                }
+            }
+
+            if (stateDictionary != null)
+            {
+                foreach (KeyValuePair<string, object> item in stateDictionary)
+                {
+                    dict[item.Key] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
+                }
+            }
+
+            if (this.ExternalScopeProvider != null)
+            {
+                StringBuilder stringBuilder = new StringBuilder();
+                this.ExternalScopeProvider.ForEachScope(
+                    (activeScope, builder) =>
+                    {
+                        // Ideally we expect that the scope to implement IReadOnlyList<KeyValuePair<string, object>>.
+                        // But this is not gauranteed as user can call BeginScope and pass anything. Hence
+                        // we try to resolve the scope as Dictionary and if we fail, we just serialize the object and add it.
+                        IReadOnlyList<KeyValuePair<string, object>> activeScopeDictionary = activeScope as IReadOnlyList<KeyValuePair<string, object>>;
+
+                        if (activeScopeDictionary != null)
+                        {
+                            foreach (KeyValuePair<string, object> item in activeScopeDictionary)
+                            {
+                                dict[item.Key] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
+                            }
+                        }
+                        else
+                        {
+                            stringBuilder.Append(" => ").Append(activeScope);
+                        }
+                    },
+                    stringBuilder);
+
+                if (stringBuilder.Length > 0)
+                {
+                    dict["Scope"] = stringBuilder.ToString();
+                }
+            }
+        }
+
+        private SeverityLevel GetSeverityLevel(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Critical:
+                    return SeverityLevel.Critical;
+                case LogLevel.Error:
+                    return SeverityLevel.Error;
+                case LogLevel.Warning:
+                    return SeverityLevel.Warning;
+                case LogLevel.Information:
+                    return SeverityLevel.Information;
+                case LogLevel.Debug:
+                case LogLevel.Trace:
+                default:
+                    return SeverityLevel.Verbose;
+            }
+        }
+    }
+}

--- a/src/ILogger/ApplicationInsightsLogger.cs
+++ b/src/ILogger/ApplicationInsightsLogger.cs
@@ -158,20 +158,17 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
             IDictionary<string, string> dict = telemetryItem.Properties;
             dict["CategoryName"] = this.categoryName;
 
-            if (!this.applicationInsightsLoggerOptions.ExcludeEventId)
+            if (eventId.Id != 0)
             {
-                if (eventId.Id != 0)
-                {
-                    dict["EventId"] = eventId.Id.ToString(CultureInfo.InvariantCulture);
-                }
-
-                if (!string.IsNullOrEmpty(eventId.Name))
-                {
-                    dict["EventName"] = eventId.Name;
-                }
+                dict["EventId"] = eventId.Id.ToString(CultureInfo.InvariantCulture);
             }
 
-            if (!this.applicationInsightsLoggerOptions.ExcludeScopeData)
+            if (!string.IsNullOrEmpty(eventId.Name))
+            {
+                dict["EventName"] = eventId.Name;
+            }
+
+            if (this.applicationInsightsLoggerOptions.IncludeScopes)
             {
                 if (state is IReadOnlyList<KeyValuePair<string, object>> stateDictionary)
                 {

--- a/src/ILogger/ApplicationInsightsLogger.cs
+++ b/src/ILogger/ApplicationInsightsLogger.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
 
             if (this.applicationInsightsLoggerOptions.IncludeScopes)
             {
-                if (state is IReadOnlyList<KeyValuePair<string, object>> stateDictionary)
+                if (state is IReadOnlyCollection<KeyValuePair<string, object>> stateDictionary)
                 {
                     foreach (KeyValuePair<string, object> item in stateDictionary)
                     {
@@ -168,7 +168,7 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
                             // But this is not guaranteed as user can call BeginScope and pass anything. Hence
                             // we try to resolve the scope as Dictionary and if we fail, we just serialize the object and add it.
 
-                            if (activeScope is IReadOnlyList<KeyValuePair<string, object>> activeScopeDictionary)
+                            if (activeScope is IReadOnlyCollection<KeyValuePair<string, object>> activeScopeDictionary)
                             {
                                 foreach (KeyValuePair<string, object> item in activeScopeDictionary)
                                 {

--- a/src/ILogger/ApplicationInsightsLogger.cs
+++ b/src/ILogger/ApplicationInsightsLogger.cs
@@ -13,14 +13,12 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
     using System.Text;
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.Implementation;
 
     /// <summary>
     /// Application insights logger implementation for <see cref="ILogger"/>.
     /// </summary>
     /// <seealso cref="ILogger" />
-    public class ApplicationInsightsLogger : ILogger, IDisposable
+    public class ApplicationInsightsLogger : ILogger
     {
         private readonly string categoryName;
         private readonly TelemetryClient telemetryClient;
@@ -36,7 +34,6 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
         {
             this.categoryName = categoryName;
             this.telemetryClient = telemetryClient;
-            this.telemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("il:");
             this.applicationInsightsLoggerOptions = applicationInsightsLoggerOptions ?? throw new ArgumentNullException(nameof(applicationInsightsLoggerOptions));
         }
 
@@ -103,23 +100,6 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
                     this.telemetryClient.TrackException(exceptionTelemetry);
                 }
             }
-        }
-
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        public void Dispose()
-        {
-            this.Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Releases unmanaged and - optionally - managed resources.
-        /// </summary>
-        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposing)
-        {
         }
 
         /// <summary>

--- a/src/ILogger/ApplicationInsightsLoggerExtensions.cs
+++ b/src/ILogger/ApplicationInsightsLoggerExtensions.cs
@@ -1,0 +1,54 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ApplicationInsightsLoggerExtensions.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation. 
+// All rights reserved.  2013
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.Extensions.Logging
+{
+    using System;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Logging.ApplicationInsights;
+
+    /// <summary>
+    /// Extensions methods to add and configure application insights logger.
+    /// </summary>
+    public static class ApplicationInsightsLoggerExtensions
+    {
+        /// <summary>
+        /// Adds an ApplicationInsights logger named 'ApplicationInsights' to the factory.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        public static ILoggingBuilder AddApplicationInsights(this ILoggingBuilder builder)
+        {
+            return builder.AddApplicationInsights((applicationInsightsOptions) => { });
+        }
+
+        /// <summary>
+        /// Adds an ApplicationInsights logger named 'ApplicationInsights' to the factory.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="configureApplicationInsightsOptions">Action to configure ApplicationInsights logger.</param>
+        public static ILoggingBuilder AddApplicationInsights(
+            this ILoggingBuilder builder,
+            Action<ApplicationInsightsLoggerOptions> configureApplicationInsightsOptions)
+        {
+            if (configureApplicationInsightsOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureApplicationInsightsOptions));
+            }
+
+            // This ensures that we don't override the TelemetryClient if one was added using .AddApplicationInsightsTelemetry()
+            // However if one was not added at the time of calling LoggerProvider, use a dummy one so that logger does not throw.
+            // .AddApplicationInsightsTelemetry() will add a configured TelemetryClient which will then override this one.
+            builder.Services.TryAdd(ServiceDescriptor.Singleton<TelemetryConfiguration, TelemetryConfiguration>());
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, ApplicationInsightsLoggerProvider>());
+            builder.Services.Configure(configureApplicationInsightsOptions);
+
+            return builder;
+        }
+    }
+}

--- a/src/ILogger/ApplicationInsightsLoggerOptions.cs
+++ b/src/ILogger/ApplicationInsightsLoggerOptions.cs
@@ -21,13 +21,8 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
         public bool TrackExceptionsAsExceptionTelemetry { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether EventId and EventName properties should be excluded from telemetry.
-        /// </summary>
-        public bool ExcludeEventId { get; set; } = false;
-
-        /// <summary>
         /// Gets or sets a value indicating whether the Scope information is excluded from telemetry or not.
         /// </summary>
-        public bool ExcludeScopeData { get; set; } = false;
+        public bool IncludeScopes { get; set; } = false;
     }
 }

--- a/src/ILogger/ApplicationInsightsLoggerOptions.cs
+++ b/src/ILogger/ApplicationInsightsLoggerOptions.cs
@@ -16,22 +16,18 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
     public class ApplicationInsightsLoggerOptions
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApplicationInsightsLoggerOptions" /> class.
-        /// Application Insights logger options can configure how <see cref="ILogger"/> behaves when sending telemetry.
-        /// </summary>
-        public ApplicationInsightsLoggerOptions()
-        {
-            this.TrackExceptionsAsExceptionTelemetry = true;
-        }
-
-        /// <summary>
         /// Gets or sets a value indicating whether to track exceptions as <see cref="ExceptionTelemetry"/>.
         /// </summary>
-        public bool TrackExceptionsAsExceptionTelemetry { get; set; }
+        public bool TrackExceptionsAsExceptionTelemetry { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether EventId and EventName properties should be included in telemetry.
+        /// Gets or sets a value indicating whether EventId and EventName properties should be excluded from telemetry.
         /// </summary>
-        public bool IncludeEventId { get; set; }
+        public bool ExcludeEventId { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the Scope information is excluded from telemetry or not.
+        /// </summary>
+        public bool ExcludeScopeData { get; set; } = false;
     }
 }

--- a/src/ILogger/ApplicationInsightsLoggerOptions.cs
+++ b/src/ILogger/ApplicationInsightsLoggerOptions.cs
@@ -1,0 +1,37 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ApplicationInsightsLoggerOptions.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation. 
+// All rights reserved.  2013
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.Extensions.Logging.ApplicationInsights
+{
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// <see cref="ApplicationInsightsLoggerOptions"/> defines the custom behavior of the tracing information sent to Application Insights.
+    /// </summary>
+    public class ApplicationInsightsLoggerOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationInsightsLoggerOptions" /> class.
+        /// Application Insights logger options can configure how <see cref="ILogger"/> behaves when sending telemetry.
+        /// </summary>
+        public ApplicationInsightsLoggerOptions()
+        {
+            this.TrackExceptionsAsExceptionTelemetry = true;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to track exceptions as <see cref="ExceptionTelemetry"/>.
+        /// </summary>
+        public bool TrackExceptionsAsExceptionTelemetry { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether EventId and EventName properties should be included in telemetry.
+        /// </summary>
+        public bool IncludeEventId { get; set; }
+    }
+}

--- a/src/ILogger/ApplicationInsightsLoggerOptions.cs
+++ b/src/ILogger/ApplicationInsightsLoggerOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
         public bool TrackExceptionsAsExceptionTelemetry { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether the Scope information is excluded from telemetry or not.
+        /// Gets or sets a value indicating whether the Scope information is included from telemetry or not.
         /// Defaults to true.
         /// </summary>
         public bool IncludeScopes { get; set; } = true;

--- a/src/ILogger/ApplicationInsightsLoggerOptions.cs
+++ b/src/ILogger/ApplicationInsightsLoggerOptions.cs
@@ -17,12 +17,14 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
     {
         /// <summary>
         /// Gets or sets a value indicating whether to track exceptions as <see cref="ExceptionTelemetry"/>.
+        /// Defaults to true.
         /// </summary>
         public bool TrackExceptionsAsExceptionTelemetry { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether the Scope information is excluded from telemetry or not.
+        /// Defaults to true.
         /// </summary>
-        public bool IncludeScopes { get; set; } = false;
+        public bool IncludeScopes { get; set; } = true;
     }
 }

--- a/src/ILogger/ApplicationInsightsLoggerProvider.cs
+++ b/src/ILogger/ApplicationInsightsLoggerProvider.cs
@@ -61,8 +61,13 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
             TelemetryConfiguration telemetryConfiguration,
             IOptions<ApplicationInsightsLoggerOptions> applicationInsightsLoggerOptions)
         {
-            this.telemetryClient = new TelemetryClient(telemetryConfiguration) ?? throw new ArgumentNullException(nameof(telemetryConfiguration));
-            this.applicationInsightsLoggerOptions = applicationInsightsLoggerOptions.Value ?? throw new ArgumentNullException(nameof(applicationInsightsLoggerOptions));
+            if (telemetryConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(telemetryConfiguration));
+            }
+
+            this.telemetryClient = new TelemetryClient(telemetryConfiguration);
+            this.applicationInsightsLoggerOptions = applicationInsightsLoggerOptions?.Value ?? throw new ArgumentNullException(nameof(applicationInsightsLoggerOptions));
         }
 
         /// <summary>

--- a/src/ILogger/ApplicationInsightsLoggerProvider.cs
+++ b/src/ILogger/ApplicationInsightsLoggerProvider.cs
@@ -9,8 +9,6 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
 {
     using System;
     using System.Collections.Concurrent;
-    using System.Collections.Generic;
-    using System.Text;
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
@@ -20,8 +18,8 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
     /// <summary>
     /// Application insights logger provider.
     /// </summary>
-    /// <seealso cref="Microsoft.Extensions.Logging.ILoggerProvider" />
-    /// <seealso cref="Microsoft.Extensions.Logging.ISupportExternalScope" />
+    /// <seealso cref="ILoggerProvider" />
+    /// <seealso cref="ISupportExternalScope" />
     [ProviderAlias("ApplicationInsights")]
     public class ApplicationInsightsLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
@@ -36,13 +34,6 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
         private readonly TelemetryClient telemetryClient;
 
         /// <summary>
-        /// The collection of application insights loggers stored against categoryName.
-        /// categoryName -> <see cref="ApplicationInsightsLogger"/> map.
-        /// </summary>
-        private readonly ConcurrentDictionary<string, ApplicationInsightsLogger> applicationInsightsLoggers
-            = new ConcurrentDictionary<string, ApplicationInsightsLogger>();
-
-        /// <summary>
         /// The external scope provider to allow setting scope data in messages.
         /// </summary>
         private IExternalScopeProvider externalScopeProvider;
@@ -50,7 +41,7 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
         /// <summary>
         /// Initializes a new instance of the <see cref="ApplicationInsightsLoggerProvider"/> class.
         /// </summary>
-        /// <param name="telemetryConfiguration">The telemetry configuration.</param>
+        /// <param name="telemetryConfigurationOptions">The telemetry configuration options..</param>
         /// <param name="applicationInsightsLoggerOptions">The application insights logger options.</param>
         /// <exception cref="System.ArgumentNullException">
         /// telemetryConfiguration
@@ -60,17 +51,17 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
         /// applicationInsightsLoggerOptions.
         /// </exception>
         public ApplicationInsightsLoggerProvider(
-            TelemetryConfiguration telemetryConfiguration,
+            IOptions<TelemetryConfiguration> telemetryConfigurationOptions,
             IOptions<ApplicationInsightsLoggerOptions> applicationInsightsLoggerOptions)
         {
-            if (telemetryConfiguration == null)
+            if (telemetryConfigurationOptions?.Value == null)
             {
-                throw new ArgumentNullException(nameof(telemetryConfiguration));
+                throw new ArgumentNullException(nameof(telemetryConfigurationOptions));
             }
 
             this.applicationInsightsLoggerOptions = applicationInsightsLoggerOptions?.Value ?? throw new ArgumentNullException(nameof(applicationInsightsLoggerOptions));
 
-            this.telemetryClient = new TelemetryClient(telemetryConfiguration);
+            this.telemetryClient = new TelemetryClient(telemetryConfigurationOptions.Value);
             this.telemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("il:");
         }
 

--- a/src/ILogger/ApplicationInsightsLoggerProvider.cs
+++ b/src/ILogger/ApplicationInsightsLoggerProvider.cs
@@ -1,0 +1,129 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ApplicationInsightsLoggerProvider.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation. 
+// All rights reserved.  2013
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.Extensions.Logging.ApplicationInsights
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Text;
+    using Microsoft.ApplicationInsights;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.Extensions.Options;
+
+    /// <summary>
+    /// Application insights logger provider.
+    /// </summary>
+    /// <seealso cref="Microsoft.Extensions.Logging.ILoggerProvider" />
+    /// <seealso cref="Microsoft.Extensions.Logging.ISupportExternalScope" />
+    [ProviderAlias("ApplicationInsights")]
+    public class ApplicationInsightsLoggerProvider : ILoggerProvider, ISupportExternalScope
+    {
+        /// <summary>
+        /// The application insights logger options.
+        /// </summary>
+        private readonly ApplicationInsightsLoggerOptions applicationInsightsLoggerOptions;
+
+        /// <summary>
+        /// The telemetry client to be used to log messages to Application Insights.
+        /// </summary>
+        private readonly TelemetryClient telemetryClient;
+
+        /// <summary>
+        /// The collection of application insights loggers stored against categoryName.
+        /// categoryName -> <see cref="ApplicationInsightsLogger"/> map.
+        /// </summary>
+        private readonly ConcurrentDictionary<string, ApplicationInsightsLogger> applicationInsightsLoggers
+            = new ConcurrentDictionary<string, ApplicationInsightsLogger>();
+
+        /// <summary>
+        /// The external scope provider to allow setting scope data in messages.
+        /// </summary>
+        private IExternalScopeProvider externalScopeProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationInsightsLoggerProvider"/> class.
+        /// </summary>
+        /// <param name="telemetryConfiguration">The telemetry configuration.</param>
+        /// <param name="applicationInsightsLoggerOptions">The application insights logger options.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// telemetryConfiguration
+        /// or
+        /// loggingFilter
+        /// or
+        /// applicationInsightsLoggerOptions.
+        /// </exception>
+        public ApplicationInsightsLoggerProvider(
+            TelemetryConfiguration telemetryConfiguration,
+            IOptions<ApplicationInsightsLoggerOptions> applicationInsightsLoggerOptions)
+        {
+            this.telemetryClient = new TelemetryClient(telemetryConfiguration) ?? throw new ArgumentNullException(nameof(telemetryConfiguration));
+            this.applicationInsightsLoggerOptions = applicationInsightsLoggerOptions.Value ?? throw new ArgumentNullException(nameof(applicationInsightsLoggerOptions));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ILogger" /> instance.
+        /// </summary>
+        /// <param name="categoryName">The category name for messages produced by the logger.</param>
+        /// <returns>An <see cref="ILogger"/> instance to be used for logging.</returns>
+        public ILogger CreateLogger(string categoryName)
+        {
+            // Word of caution : GetOrAdd function is not fully threadsafe. The delegate to create
+            // new objects is not run under lock so we might create multiple ApplicationInsightsLoggers.
+            // However this will only typically during first time a specific code path is getting hit.
+            // Since ApplicationInsightsLoggers are harmless we are ready to live with this. However
+            // if in future this changes, Lazy<> approach can be used.
+            return this.applicationInsightsLoggers.GetOrAdd(
+                categoryName,
+                loggerName => new ApplicationInsightsLogger(
+                    loggerName,
+                    this.telemetryClient,
+                    this.applicationInsightsLoggerOptions)
+                {
+                    ExternalScopeProvider = this.externalScopeProvider,
+                });
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Sets the scope provider. This method also updates all the existing logger to also use the new ScopeProvider.
+        /// </summary>
+        /// <param name="externalScopeProvider">The external scope provider.</param>
+        public void SetScopeProvider(IExternalScopeProvider externalScopeProvider)
+        {
+            // First set the ScopeProvider to ensure the newer instances get the newer instance.
+            this.externalScopeProvider = externalScopeProvider;
+
+            // Then update all the existing loggers regardless of their current scope provider.
+            foreach (var logger in this.applicationInsightsLoggers)
+            {
+                logger.Value.ExternalScopeProvider = externalScopeProvider;
+            }
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            // Dispose all appInsights loggers.
+            foreach (var logger in this.applicationInsightsLoggers)
+            {
+                logger.Value.Dispose();
+            }
+        }
+    }
+}

--- a/src/ILogger/ApplicationInsightsLoggingBuilderExtensions.cs
+++ b/src/ILogger/ApplicationInsightsLoggingBuilderExtensions.cs
@@ -22,9 +22,42 @@ namespace Microsoft.Extensions.Logging
         /// Adds an ApplicationInsights logger named 'ApplicationInsights' to the factory.
         /// </summary>
         /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <returns>Logging builder with Application Insights added to it.</returns>
         public static ILoggingBuilder AddApplicationInsights(this ILoggingBuilder builder)
         {
             return builder.AddApplicationInsights((applicationInsightsOptions) => { });
+        }
+
+        /// <summary>
+        /// Adds an ApplicationInsights logger named 'ApplicationInsights' to the factory.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="instrumentationKey">Application insights instrumentation key.</param>
+        /// <returns>Logging builder with Application Insights added to it.</returns>
+        public static ILoggingBuilder AddApplicationInsights(
+            this ILoggingBuilder builder,
+            string instrumentationKey)
+        {
+            return builder.AddApplicationInsights(
+                (telemetryConfiguration) => telemetryConfiguration.InstrumentationKey = instrumentationKey,
+                (applicationInsightsOptions) => { });
+        }
+
+        /// <summary>
+        /// Adds an ApplicationInsights logger named 'ApplicationInsights' to the factory.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="instrumentationKey">Application insights instrumentation key.</param>
+        /// <param name="configureApplicationInsightsOptions">Action to configure ApplicationInsights logger.</param>
+        /// <returns>Logging builder with Application Insights added to it.</returns>
+        public static ILoggingBuilder AddApplicationInsights(
+            this ILoggingBuilder builder,
+            string instrumentationKey,
+            Action<ApplicationInsightsLoggerOptions> configureApplicationInsightsOptions)
+        {
+            return builder.AddApplicationInsights(
+                (telemetryConfiguration) => telemetryConfiguration.InstrumentationKey = instrumentationKey,
+                configureApplicationInsightsOptions);
         }
 
         /// <summary>
@@ -36,13 +69,29 @@ namespace Microsoft.Extensions.Logging
             this ILoggingBuilder builder,
             Action<ApplicationInsightsLoggerOptions> configureApplicationInsightsOptions)
         {
+            return builder.AddApplicationInsights(
+                (telemetryConfiguration) => { },
+                configureApplicationInsightsOptions);
+        }
+
+        /// <summary>
+        /// Adds an ApplicationInsights logger named 'ApplicationInsights' to the factory.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="configureTelemetryConfiguration">Action to configure telemetry configuration.</param>
+        /// <param name="configureApplicationInsightsOptions">Action to configure ApplicationInsights logger.</param>
+        private static ILoggingBuilder AddApplicationInsights(
+            this ILoggingBuilder builder,
+            Action<TelemetryConfiguration> configureTelemetryConfiguration,
+            Action<ApplicationInsightsLoggerOptions> configureApplicationInsightsOptions)
+        {
             if (configureApplicationInsightsOptions == null)
             {
                 throw new ArgumentNullException(nameof(configureApplicationInsightsOptions));
             }
 
             // Initialize IOptions<TelemetryConfiguration> user can keep on configuring it furthur if they want to.
-            builder.Services.Configure<TelemetryConfiguration>((telemetryConfiguration) => { });
+            builder.Services.Configure<TelemetryConfiguration>(configureTelemetryConfiguration);
 
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, ApplicationInsightsLoggerProvider>());
             builder.Services.Configure(configureApplicationInsightsOptions);

--- a/src/ILogger/ApplicationInsightsLoggingBuilderExtensions.cs
+++ b/src/ILogger/ApplicationInsightsLoggingBuilderExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="ApplicationInsightsLoggerExtensions.cs" company="Microsoft">
+// <copyright file="ApplicationInsightsLoggingBuilderExtensions.cs" company="Microsoft">
 // Copyright (c) Microsoft Corporation. 
 // All rights reserved.  2013
 // </copyright>
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.Logging
     /// <summary>
     /// Extensions methods to add and configure application insights logger.
     /// </summary>
-    public static class ApplicationInsightsLoggerExtensions
+    public static class ApplicationInsightsLoggingBuilderExtensions
     {
         /// <summary>
         /// Adds an ApplicationInsights logger named 'ApplicationInsights' to the factory.

--- a/src/ILogger/ApplicationInsightsLoggingBuilderExtensions.cs
+++ b/src/ILogger/ApplicationInsightsLoggingBuilderExtensions.cs
@@ -41,10 +41,9 @@ namespace Microsoft.Extensions.Logging
                 throw new ArgumentNullException(nameof(configureApplicationInsightsOptions));
             }
 
-            // This ensures that we don't override the TelemetryClient if one was added using .AddApplicationInsightsTelemetry()
-            // However if one was not added at the time of calling LoggerProvider, use a dummy one so that logger does not throw.
-            // .AddApplicationInsightsTelemetry() will add a configured TelemetryClient which will then override this one.
-            builder.Services.TryAdd(ServiceDescriptor.Singleton<TelemetryConfiguration, TelemetryConfiguration>());
+            // Initialize IOptions<TelemetryConfiguration> user can keep on configuring it furthur if they want to.
+            builder.Services.Configure<TelemetryConfiguration>((telemetryConfiguration) => { });
+
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, ApplicationInsightsLoggerProvider>());
             builder.Services.Configure(configureApplicationInsightsOptions);
 

--- a/src/ILogger/ApplicationInsightsLoggingBuilderExtensions.cs
+++ b/src/ILogger/ApplicationInsightsLoggingBuilderExtensions.cs
@@ -48,30 +48,30 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
         /// <param name="instrumentationKey">Application insights instrumentation key.</param>
-        /// <param name="configureApplicationInsightsOptions">Action to configure ApplicationInsights logger.</param>
+        /// <param name="configureApplicationInsightsLoggerOptions">Action to configure ApplicationInsights logger.</param>
         /// <returns>Logging builder with Application Insights added to it.</returns>
         public static ILoggingBuilder AddApplicationInsights(
             this ILoggingBuilder builder,
             string instrumentationKey,
-            Action<ApplicationInsightsLoggerOptions> configureApplicationInsightsOptions)
+            Action<ApplicationInsightsLoggerOptions> configureApplicationInsightsLoggerOptions)
         {
             return builder.AddApplicationInsights(
                 (telemetryConfiguration) => telemetryConfiguration.InstrumentationKey = instrumentationKey,
-                configureApplicationInsightsOptions);
+                configureApplicationInsightsLoggerOptions);
         }
 
         /// <summary>
         /// Adds an ApplicationInsights logger named 'ApplicationInsights' to the factory.
         /// </summary>
         /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
-        /// <param name="configureApplicationInsightsOptions">Action to configure ApplicationInsights logger.</param>
+        /// <param name="configureApplicationInsightsLoggerOptions">Action to configure ApplicationInsights logger.</param>
         public static ILoggingBuilder AddApplicationInsights(
             this ILoggingBuilder builder,
-            Action<ApplicationInsightsLoggerOptions> configureApplicationInsightsOptions)
+            Action<ApplicationInsightsLoggerOptions> configureApplicationInsightsLoggerOptions)
         {
             return builder.AddApplicationInsights(
                 (telemetryConfiguration) => { },
-                configureApplicationInsightsOptions);
+                configureApplicationInsightsLoggerOptions);
         }
 
         /// <summary>
@@ -79,22 +79,22 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
         /// <param name="configureTelemetryConfiguration">Action to configure telemetry configuration.</param>
-        /// <param name="configureApplicationInsightsOptions">Action to configure ApplicationInsights logger.</param>
+        /// <param name="configureApplicationInsightsLoggerOptions">Action to configure ApplicationInsights logger.</param>
         private static ILoggingBuilder AddApplicationInsights(
             this ILoggingBuilder builder,
             Action<TelemetryConfiguration> configureTelemetryConfiguration,
-            Action<ApplicationInsightsLoggerOptions> configureApplicationInsightsOptions)
+            Action<ApplicationInsightsLoggerOptions> configureApplicationInsightsLoggerOptions)
         {
-            if (configureApplicationInsightsOptions == null)
+            if (configureApplicationInsightsLoggerOptions == null)
             {
-                throw new ArgumentNullException(nameof(configureApplicationInsightsOptions));
+                throw new ArgumentNullException(nameof(configureApplicationInsightsLoggerOptions));
             }
 
             // Initialize IOptions<TelemetryConfiguration> user can keep on configuring it furthur if they want to.
             builder.Services.Configure<TelemetryConfiguration>(configureTelemetryConfiguration);
 
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, ApplicationInsightsLoggerProvider>());
-            builder.Services.Configure(configureApplicationInsightsOptions);
+            builder.Services.Configure(configureApplicationInsightsLoggerOptions);
 
             return builder;
         }

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <RootNamespace>Microsoft.Extensions.Logging.ApplicationInsights</RootNamespace>
+    <AssemblyName>Microsoft.Extensions.Logging.ApplicationInsights</AssemblyName>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
+  </PropertyGroup>
+
+  <!-- Import is done after first property group because Product.props use AssemblyName property. -->
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
+
+  <PropertyGroup>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <IncludeSymbols>True</IncludeSymbols>
+    <PackageId>Microsoft.Extensions.Logging.ApplicationInsights</PackageId>
+    <Title>Microsoft Logging Extensions for ApplicationInsights</Title>
+    <Description>Application Insights ILogger allows forwarding events from ILogger to Application Insights. Application Insights will collect your logs from multiple sources and provide rich powerful search capabilities. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>
+    <PackageTags>$(PackageTags) ILogger ILoggerBuilder</PackageTags>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateAdditionalSources>false</GenerateAdditionalSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Desktop.Analyzers" Version="1.2.0-beta2">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microbuild.Core" Version="0.3.0">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
+  </ItemGroup>
+
+  <Import Project="..\CommonShared\CommonShared.projitems" Label="Shared" />
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.targets'))\Common.targets" />
+</Project>

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -8,6 +8,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <RunCodeAnalysis>false</RunCodeAnalysis>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <!-- Import is done after first property group because Product.props use AssemblyName property. -->

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -8,6 +8,15 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <RunCodeAnalysis>false</RunCodeAnalysis>
+    <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- Include the PDB in the built .nupkg -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+
   </PropertyGroup>
 
   <!-- Import is done after first property group because Product.props use AssemblyName property. -->
@@ -21,11 +30,8 @@
     <Description>Application Insights ILogger allows forwarding events from ILogger to Application Insights. Application Insights will collect your logs from multiple sources and provide rich powerful search capabilities. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>
     <PackageTags>$(PackageTags) ILogger ILoggerBuilder ILoggerProvider</PackageTags>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
+  
+  
 
   <PropertyGroup>
     <GenerateAdditionalSources>false</GenerateAdditionalSources>
@@ -35,6 +41,10 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2">
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>All</PrivateAssets>

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta009">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Desktop.Analyzers" Version="1.2.0-beta2">
+    <PackageReference Include="Desktop.Analyzers" Version="1.1.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microbuild.Core" Version="0.3.0">

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.Extensions.Logging.ApplicationInsights</RootNamespace>
     <AssemblyName>Microsoft.Extensions.Logging.ApplicationInsights</AssemblyName>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>Microsoft.Extensions.Logging.ApplicationInsights</RootNamespace>
     <AssemblyName>Microsoft.Extensions.Logging.ApplicationInsights</AssemblyName>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -30,8 +30,11 @@
     <Description>Application Insights ILogger allows forwarding events from ILogger to Application Insights. Application Insights will collect your logs from multiple sources and provide rich powerful search capabilities. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>
     <PackageTags>$(PackageTags) ILogger ILoggerBuilder ILoggerProvider</PackageTags>
   </PropertyGroup>
-  
-  
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 
   <PropertyGroup>
     <GenerateAdditionalSources>false</GenerateAdditionalSources>

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.0-beta2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -19,7 +19,7 @@
     <PackageId>Microsoft.Extensions.Logging.ApplicationInsights</PackageId>
     <Title>Microsoft Logging Extensions for ApplicationInsights</Title>
     <Description>Application Insights ILogger allows forwarding events from ILogger to Application Insights. Application Insights will collect your logs from multiple sources and provide rich powerful search capabilities. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>
-    <PackageTags>$(PackageTags) ILogger ILoggerBuilder</PackageTags>
+    <PackageTags>$(PackageTags) ILogger ILoggerBuilder ILoggerProvider</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -8,7 +8,6 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <RunCodeAnalysis>false</RunCodeAnalysis>
-    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <!-- Import is done after first property group because Product.props use AssemblyName property. -->

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -49,7 +49,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta009">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Desktop.Analyzers" Version="1.2.0-beta2">

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -42,19 +42,19 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2">
+    <!--<PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2">
       <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    </PackageReference>-->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta009">
+    <!--<PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta009">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0">
       <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
+    </PackageReference>-->
     <PackageReference Include="Microbuild.Core" Version="0.3.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.0-beta2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/ILogger/NullScope.cs
+++ b/src/ILogger/NullScope.cs
@@ -1,0 +1,32 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="NullScope.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation. 
+// All rights reserved.  2013
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.Extensions.Logging.ApplicationInsights
+{
+    using System;
+
+    /// <summary>
+    /// An empty scope without any logic.
+    /// </summary>
+    internal class NullScope : IDisposable
+    {
+        private NullScope()
+        {
+        }
+
+        public static NullScope Instance { get; } = new NullScope();
+
+#pragma warning disable CA1063 // Implement IDisposable Correctly - Nothing at all to dispose.
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+#pragma warning restore CA1063 // Implement IDisposable Correctly - Nothing at all to dispose.
+        {
+        }
+    }
+}

--- a/test/ILogger.NetStandard.Tests/ILogger.NetStandard.Tests.csproj
+++ b/test/ILogger.NetStandard.Tests/ILogger.NetStandard.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
-    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ILogger.NetStandard.Tests/ILogger.NetStandard.Tests.csproj
+++ b/test/ILogger.NetStandard.Tests/ILogger.NetStandard.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <IsPackable>false</IsPackable>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ILogger\ILogger.csproj" />
+  </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
+
+  <Import Project="..\Shared\Adapters.Shared.Tests.projitems" Label="Shared" Condition="Exists('..\Shared\Adapters.Shared.Tests.projitems')" />
+  <Import Project="..\CommonTestShared\CommonTestShared.projitems" Label="Shared" Condition="Exists('..\CommonTestShared\CommonTestShared.projitems')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.targets'))\Common.targets" />
+</Project>

--- a/test/ILogger.NetStandard.Tests/ILoggerIntegrationTests.cs
+++ b/test/ILogger.NetStandard.Tests/ILoggerIntegrationTests.cs
@@ -55,6 +55,22 @@ namespace Microsoft.ApplicationInsights
 
             Assert.AreEqual("Microsoft.ApplicationInsights.ILoggerIntegrationTests", (itemsReceived[2] as ISupportProperties).Properties["CategoryName"]);
             Assert.AreEqual("Microsoft.ApplicationInsights.ILoggerIntegrationTests", (itemsReceived[0] as ISupportProperties).Properties["CategoryName"]);
+
+            Assert.AreEqual(SeverityLevel.Information, (itemsReceived[0] as TraceTelemetry).SeverityLevel);
+            Assert.AreEqual(SeverityLevel.Error, (itemsReceived[1] as ExceptionTelemetry).SeverityLevel);
+            Assert.AreEqual(SeverityLevel.Information, (itemsReceived[2] as TraceTelemetry).SeverityLevel);
+            Assert.AreEqual(SeverityLevel.Critical, (itemsReceived[3] as TraceTelemetry).SeverityLevel);
+            Assert.AreEqual(SeverityLevel.Verbose, (itemsReceived[4] as TraceTelemetry).SeverityLevel);
+            Assert.AreEqual(SeverityLevel.Warning, (itemsReceived[5] as TraceTelemetry).SeverityLevel);
+            Assert.AreEqual(SeverityLevel.Verbose, (itemsReceived[6] as TraceTelemetry).SeverityLevel);
+
+            Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
+            Assert.AreEqual("Exception", (itemsReceived[1] as ExceptionTelemetry).Message);
+            Assert.AreEqual("TestingEvent", (itemsReceived[2] as TraceTelemetry).Message);
+            Assert.AreEqual("Critical", (itemsReceived[3] as TraceTelemetry).Message);
+            Assert.AreEqual("Trace", (itemsReceived[4] as TraceTelemetry).Message);
+            Assert.AreEqual("Warning", (itemsReceived[5] as TraceTelemetry).Message);
+            Assert.AreEqual("Debug", (itemsReceived[6] as TraceTelemetry).Message);
         }
 
         /// <summary>
@@ -81,10 +97,7 @@ namespace Microsoft.ApplicationInsights
             Assert.IsInstanceOfType(itemsReceived[0], typeof(TraceTelemetry));
             Assert.IsInstanceOfType(itemsReceived[1], typeof(ExceptionTelemetry));
 
-            Assert.AreEqual(SeverityLevel.Information, (itemsReceived[0] as TraceTelemetry).SeverityLevel);
             Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
-
-            Assert.AreEqual(SeverityLevel.Error, (itemsReceived[1] as ExceptionTelemetry).SeverityLevel);
             Assert.AreEqual("Exception", (itemsReceived[1] as ExceptionTelemetry).Message);
         }
 
@@ -136,11 +149,14 @@ namespace Microsoft.ApplicationInsights
 
             ILogger<ILoggerIntegrationTests> testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
 
-            testLogger.BeginScope("TestScope");
-            testLogger.BeginScope<IReadOnlyCollection<KeyValuePair<string, object>>>(new Dictionary<string, object> { { "Key", "Value" } });
-
-            testLogger.LogInformation("Testing");
-            testLogger.LogError(new Exception("TestException"), "Exception");
+            using (testLogger.BeginScope("TestScope"))
+            {
+                using (testLogger.BeginScope<IReadOnlyCollection<KeyValuePair<string, object>>>(new Dictionary<string, object> { { "Key", "Value" } }))
+                {
+                    testLogger.LogInformation("Testing");
+                    testLogger.LogError(new Exception("TestException"), "Exception");
+                }
+            }
 
             Assert.AreEqual(" => TestScope", (itemsReceived[0] as ISupportProperties).Properties["Scope"]);
             Assert.AreEqual("Value", (itemsReceived[0] as ISupportProperties).Properties["Key"]);
@@ -167,11 +183,14 @@ namespace Microsoft.ApplicationInsights
 
             ILogger<ILoggerIntegrationTests> testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
 
-            testLogger.BeginScope("TestScope");
-            testLogger.BeginScope<IReadOnlyCollection<KeyValuePair<string, object>>>(new Dictionary<string, object> { { "Key", "Value" } });
-
-            testLogger.LogInformation("Testing");
-            testLogger.LogError(new Exception("TestException"), "Exception");
+            using (testLogger.BeginScope("TestScope"))
+            {
+                using (testLogger.BeginScope<IReadOnlyCollection<KeyValuePair<string, object>>>(new Dictionary<string, object> { { "Key", "Value" } }))
+                {
+                    testLogger.LogInformation("Testing");
+                    testLogger.LogError(new Exception("TestException"), "Exception");
+                }
+            }
 
             Assert.IsFalse((itemsReceived[0] as ISupportProperties).Properties.ContainsKey("Scope"));
             Assert.IsFalse((itemsReceived[0] as ISupportProperties).Properties.ContainsKey("Key"));

--- a/test/ILogger.NetStandard.Tests/ILoggerIntegrationTests.cs
+++ b/test/ILogger.NetStandard.Tests/ILoggerIntegrationTests.cs
@@ -163,6 +163,9 @@ namespace Microsoft.ApplicationInsights
 
             Assert.AreEqual(" => TestScope", (itemsReceived[1] as ISupportProperties).Properties["Scope"]);
             Assert.AreEqual("Value", (itemsReceived[1] as ISupportProperties).Properties["Key"]);
+
+            Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
+            Assert.AreEqual("Exception", (itemsReceived[1] as ExceptionTelemetry).Message);
         }
 
         /// <summary>
@@ -171,7 +174,7 @@ namespace Microsoft.ApplicationInsights
         /// </summary>
         [TestMethod]
         [TestCategory("ILogger")]
-        public void ApplicationInsightsLoggerAddsScopeWhenSwitchIsFalse()
+        public void ApplicationInsightsLoggerDoesNotAddScopeWhenSwitchIsFalse()
         {
             List<ITelemetry> itemsReceived = new List<ITelemetry>();
 
@@ -197,6 +200,9 @@ namespace Microsoft.ApplicationInsights
 
             Assert.IsFalse((itemsReceived[1] as ISupportProperties).Properties.ContainsKey("Scope"));
             Assert.IsFalse((itemsReceived[1] as ISupportProperties).Properties.ContainsKey("Key"));
+
+            Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
+            Assert.AreEqual("Exception", (itemsReceived[1] as ExceptionTelemetry).Message);
         }
 
         /// <summary>

--- a/test/ILogger.NetStandard.Tests/ILoggerIntegrationTests.cs
+++ b/test/ILogger.NetStandard.Tests/ILoggerIntegrationTests.cs
@@ -1,0 +1,236 @@
+﻿// <copyright file="ILoggerIntegrationTests.cs" company="Microsoft">
+// Copyright © Microsoft. All Rights Reserved.
+// </copyright>
+
+namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.ApplicationInsights;
+    using Microsoft.Extensions.Options;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Tests the <see cref="ILogger"/> integration for Application Insights.
+    /// </summary>
+    [TestClass]
+    public class ILoggerIntegrationTests
+    {
+        /// <summary>
+        /// Ensures that <see cref="ApplicationInsightsLogger"/> is invoked when user logs using <see cref="ILogger"/>.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ILogger")]
+        public void ApplicationInsightsLoggerIsInvokedWhenUsingILogger()
+        {
+            List<ITelemetry> itemsReceived = new List<ITelemetry>();
+
+            IServiceProvider serviceProvider = ILoggerIntegrationTests.SetupApplicationInsightsLoggerIntegration((telemetryItem, telemetryProcessor) =>
+            {
+                itemsReceived.Add(telemetryItem);
+            });
+
+            ILogger<ILoggerIntegrationTests> testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
+
+            testLogger.LogInformation("Testing");
+            testLogger.LogError(new Exception("TestException"), "Exception");
+            testLogger.LogInformation(new EventId(100, "TestEvent"), "TestingEvent");
+            testLogger.LogCritical("Critical");
+            testLogger.LogTrace("Trace");
+            testLogger.LogWarning("Warning");
+            testLogger.LogDebug("Debug");
+
+            Assert.AreEqual(7, itemsReceived.Count);
+
+            Assert.IsTrue((itemsReceived[2] as ISupportProperties).Properties.ContainsKey("EventId"));
+            Assert.IsTrue((itemsReceived[2] as ISupportProperties).Properties.ContainsKey("EventName"));
+            Assert.AreEqual("100", (itemsReceived[2] as ISupportProperties).Properties["EventId"]);
+            Assert.AreEqual("TestEvent", (itemsReceived[2] as ISupportProperties).Properties["EventName"]);
+
+            Assert.AreEqual("Microsoft.ApplicationInsights.ILoggerIntegrationTests", (itemsReceived[2] as ISupportProperties).Properties["CategoryName"]);
+            Assert.AreEqual("Microsoft.ApplicationInsights.ILoggerIntegrationTests", (itemsReceived[0] as ISupportProperties).Properties["CategoryName"]);
+        }
+
+        /// <summary>
+        /// Ensures that the <see cref="ApplicationInsightsLoggerOptions.TrackExceptionsAsExceptionTelemetry"/> switch is honored.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ILogger")]
+        public void ApplicationInsightsLoggerHonorsLogExceptionsAsExceptionTelemetrySwitch()
+        {
+            List<ITelemetry> itemsReceived = new List<ITelemetry>();
+
+            // Case where Exceptions are logged as Exception Telemetry.
+            IServiceProvider serviceProvider = ILoggerIntegrationTests.SetupApplicationInsightsLoggerIntegration(
+                (telemetryItem, telemetryProcessor) => itemsReceived.Add(telemetryItem),
+                configureTelemetryConfiguration: null,
+                configureApplicationInsightsOptions: (appInsightsLoggerOptions) => appInsightsLoggerOptions.TrackExceptionsAsExceptionTelemetry = true);
+
+            ILogger<ILoggerIntegrationTests> testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
+
+            testLogger.LogInformation("Testing");
+            testLogger.LogError(new Exception("TestException"), "Exception");
+
+            Assert.IsInstanceOfType(itemsReceived[0], typeof(TraceTelemetry));
+            Assert.IsInstanceOfType(itemsReceived[1], typeof(ExceptionTelemetry));
+
+            Assert.AreEqual(SeverityLevel.Information, (itemsReceived[0] as TraceTelemetry).SeverityLevel);
+            Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
+
+            Assert.AreEqual(SeverityLevel.Error, (itemsReceived[1] as ExceptionTelemetry).SeverityLevel);
+            Assert.AreEqual("Exception", (itemsReceived[1] as ExceptionTelemetry).Message);
+
+            itemsReceived.Clear();
+
+            // Case where Exceptions are logged as Trace Telemetry.
+            serviceProvider = ILoggerIntegrationTests.SetupApplicationInsightsLoggerIntegration(
+                (telemetryItem, telemetryProcessor) => itemsReceived.Add(telemetryItem),
+                configureTelemetryConfiguration: null,
+                configureApplicationInsightsOptions: (appInsightsLoggerOptions) => appInsightsLoggerOptions.TrackExceptionsAsExceptionTelemetry = false);
+
+            testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
+
+            testLogger.LogInformation("Testing");
+            testLogger.LogError(new Exception("TestException"), "Exception");
+
+            Assert.IsInstanceOfType(itemsReceived[0], typeof(TraceTelemetry));
+            Assert.IsInstanceOfType(itemsReceived[1], typeof(TraceTelemetry));
+
+            Assert.AreEqual(SeverityLevel.Information, (itemsReceived[0] as TraceTelemetry).SeverityLevel);
+            Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
+
+            Assert.AreEqual(SeverityLevel.Error, (itemsReceived[1] as TraceTelemetry).SeverityLevel);
+            Assert.AreEqual("Exception", (itemsReceived[1] as TraceTelemetry).Message);
+        }
+
+        /// <summary>
+        /// Ensures that the <see cref="ApplicationInsightsLoggerOptions.IncludeScopes"/> switch is honored.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ILogger")]
+        public void ApplicationInsightsLoggerHonorsIncludeScopeSwitch()
+        {
+            List<ITelemetry> itemsReceived = new List<ITelemetry>();
+
+            // Case where Scope is included.
+            IServiceProvider serviceProvider = ILoggerIntegrationTests.SetupApplicationInsightsLoggerIntegration(
+                (telemetryItem, telemetryProcessor) => itemsReceived.Add(telemetryItem),
+                configureTelemetryConfiguration: null,
+                configureApplicationInsightsOptions: (appInsightsLoggerOptions) => appInsightsLoggerOptions.IncludeScopes = true);
+
+            ILogger<ILoggerIntegrationTests> testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
+
+            testLogger.BeginScope("TestScope");
+            testLogger.BeginScope<IReadOnlyCollection<KeyValuePair<string, object>>>(new Dictionary<string, object> { { "Key", "Value" } });
+
+            testLogger.LogInformation("Testing");
+            testLogger.LogError(new Exception("TestException"), "Exception");
+
+            Assert.AreEqual(" => TestScope", (itemsReceived[0] as ISupportProperties).Properties["Scope"]);
+            Assert.AreEqual("Value", (itemsReceived[0] as ISupportProperties).Properties["Key"]);
+
+            Assert.AreEqual(" => TestScope", (itemsReceived[1] as ISupportProperties).Properties["Scope"]);
+            Assert.AreEqual("Value", (itemsReceived[1] as ISupportProperties).Properties["Key"]);
+
+            itemsReceived.Clear();
+
+            // Case where Scope is NOT Included
+            serviceProvider = ILoggerIntegrationTests.SetupApplicationInsightsLoggerIntegration(
+                (telemetryItem, telemetryProcessor) => itemsReceived.Add(telemetryItem),
+                configureTelemetryConfiguration: null,
+                configureApplicationInsightsOptions: (appInsightsLoggerOptions) => appInsightsLoggerOptions.IncludeScopes = false);
+
+            testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
+
+            testLogger.BeginScope("TestScope");
+            testLogger.BeginScope<IReadOnlyCollection<KeyValuePair<string, object>>>(new Dictionary<string, object> { { "Key", "Value" } });
+
+            testLogger.LogInformation("Testing");
+            testLogger.LogError(new Exception("TestException"), "Exception");
+
+            Assert.IsFalse((itemsReceived[0] as ISupportProperties).Properties.ContainsKey("Scope"));
+            Assert.IsFalse((itemsReceived[0] as ISupportProperties).Properties.ContainsKey("Key"));
+
+            Assert.IsFalse((itemsReceived[1] as ISupportProperties).Properties.ContainsKey("Scope"));
+            Assert.IsFalse((itemsReceived[1] as ISupportProperties).Properties.ContainsKey("Key"));
+        }
+
+        /// <summary>
+        /// Ensures that the default <see cref="ApplicationInsightsLoggerOptions"/> are as expected.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ILogger")]
+        public void DefaultLoggerOptionsAreCorrectlyRegistered()
+        {
+            IServiceProvider serviceProvider = ILoggerIntegrationTests.SetupApplicationInsightsLoggerIntegration(
+                (telemetryItem, telemetryProcessor) => { });
+
+            IOptions<ApplicationInsightsLoggerOptions> registeredOptions = 
+                serviceProvider.GetRequiredService<IOptions<ApplicationInsightsLoggerOptions>>();
+
+            Assert.IsTrue(registeredOptions.Value.TrackExceptionsAsExceptionTelemetry);
+            Assert.IsTrue(registeredOptions.Value.IncludeScopes);
+        }
+
+        /// <summary>
+        /// Sets up the Application insights logger.
+        /// </summary>
+        /// <param name="telemetryActionCallback">Callback to execute when telemetry items are emitted.</param>
+        /// <param name="configureTelemetryConfiguration">Action to configure telemetry configuration.</param>
+        /// <param name="configureApplicationInsightsOptions">Action to configure logger options.</param>
+        /// <param name="configureServices">Action to add, configure services to DI container.</param>
+        /// <returns>Built DI container.</returns>
+        private static IServiceProvider SetupApplicationInsightsLoggerIntegration(
+            Action<ITelemetry, ITelemetryProcessor> telemetryActionCallback,
+            Action<TelemetryConfiguration> configureTelemetryConfiguration = null,
+            Action<ApplicationInsightsLoggerOptions> configureApplicationInsightsOptions = null,
+            Func<IServiceCollection, IServiceCollection> configureServices = null)
+        {
+            // Create DI container.
+            IServiceCollection services = new ServiceCollection();
+
+            // Configure the Telemetry configuration to be used to send data to AI.
+            services.Configure<TelemetryConfiguration>(telemetryConfiguration =>
+            {
+                telemetryConfiguration.TelemetryProcessorChainBuilder.Use((existingProcessor) =>
+                {
+                    return new TestTelemetryProcessor(existingProcessor, telemetryActionCallback);
+                }).Build();
+            });
+
+            if (configureTelemetryConfiguration != null)
+            {
+                services.Configure<TelemetryConfiguration>(configureTelemetryConfiguration);
+            }
+
+            services.AddLogging(loggingBuilder =>
+            {
+                if (configureApplicationInsightsOptions != null)
+                {
+                    loggingBuilder.AddApplicationInsights(configureApplicationInsightsOptions);
+                }
+                else
+                {
+                    loggingBuilder.AddApplicationInsights();
+                }
+
+                loggingBuilder.SetMinimumLevel(LogLevel.Trace);
+            });
+
+            if (configureServices != null)
+            {
+                services = configureServices.Invoke(services);
+            }
+
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            return serviceProvider;
+        }
+    }
+}

--- a/test/ILogger.NetStandard.Tests/TestTelemetryProcessor.cs
+++ b/test/ILogger.NetStandard.Tests/TestTelemetryProcessor.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Microsoft.ApplicationInsights
+{
+    /// <summary>
+    /// Test telemetry processor which gives access to the telemetry items as it passes through the pipeline.
+    /// </summary>
+    internal class TestTelemetryProcessor : ITelemetryProcessor
+    {
+        private readonly ITelemetryProcessor nextTelemetryProcessor;
+        private readonly Action<ITelemetry, ITelemetryProcessor> telemetryActionCallback;
+
+        /// <summary>
+        /// Initializes a new instances of the <see cref="TestTelemetryProcessor"/> class.
+        /// </summary>
+        /// <param name="nextTelemetryProcessor">Next telemetry processor to invoke.</param>
+        /// <param name="telemetryActionCallback">Action to invoke when the telemetry item is received.</param>
+        public TestTelemetryProcessor(ITelemetryProcessor nextTelemetryProcessor, Action<ITelemetry, ITelemetryProcessor> telemetryActionCallback)
+        {
+            this.nextTelemetryProcessor = nextTelemetryProcessor;
+            this.telemetryActionCallback = telemetryActionCallback;
+        }
+
+        /// <summary>
+        /// Invokes the callback registered by the user.
+        /// </summary>
+        /// <param name="item">Telemetry item.</param>
+        public void Process(ITelemetry item)
+        {
+            telemetryActionCallback.Invoke(item, this.nextTelemetryProcessor);
+        }
+    }
+}


### PR DESCRIPTION
Original discussion at -  https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/749


### C# Console program sample

Packages installed 

```xml
<ItemGroup>
    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.8.1-build39946" />
    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" />
  </ItemGroup>
```

```cs
class Program
    {
        static void Main(string[] args)
        {
            // Create DI container.
            IServiceCollection services = new ServiceCollection();
            
            // Add the logging pipelines to use. We are using Console and AI and configuring them both.
            services.AddLogging(loggingBuilder =>
            {
                loggingBuilder.AddApplicationInsights("--YourAIKeyHere--");

                loggingBuilder.AddConsole();
            });

            // Build ServiceProvider.
            IServiceProvider serviceProvider = services.BuildServiceProvider();

            ILogger<Program> logger = serviceProvider.GetRequiredService<ILogger<Program>>();

            // Begin a new scope. This is optional. Epecially in case of AspNetCore request info is already
            // present in scope.
            using (logger.BeginScope(new Dictionary<string, object> { { "Method", nameof(Main) } }))
            {
                logger.LogInformation("Logger is working");
            }
        }
    }
```