### PR TITLE
Fix fxcop running on netstandard2.0 and failing

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -19,7 +19,6 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>

--- a/src/EtwCollector/EtwCollector.csproj
+++ b/src/EtwCollector/EtwCollector.csproj
@@ -15,6 +15,8 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <RootNamespace>Microsoft.ApplicationInsights.EtwCollector</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.EtwCollector</AssemblyName>
+
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
 

--- a/src/EventSourceListener/EventSourceListener.csproj
+++ b/src/EventSourceListener/EventSourceListener.csproj
@@ -8,6 +8,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   
   <!-- Import is done after first property group because Product.props use AssemblyName property. -->

--- a/src/Log4NetAppender/Log4NetAppender.csproj
+++ b/src/Log4NetAppender/Log4NetAppender.csproj
@@ -12,6 +12,7 @@
 
     <RootNamespace>Microsoft.ApplicationInsights.Log4NetAppender</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.Log4NetAppender</AssemblyName>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NLogTarget/NLogTarget.csproj
+++ b/src/NLogTarget/NLogTarget.csproj
@@ -12,6 +12,7 @@
 
     <RootNamespace>Microsoft.ApplicationInsights.NLogTarget</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.NLogTarget</AssemblyName>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/TraceListener/TraceListener.csproj
+++ b/src/TraceListener/TraceListener.csproj
@@ -11,6 +11,7 @@
 
     <RootNamespace>Microsoft.ApplicationInsights.TraceListener</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.TraceListener</AssemblyName>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
In https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/239 new ILogger was introduced that targets netstandard 2.0 and build fails because of code analyzers 

```
CA0055 : Could not identify platform for 'E:\A\_work\107\bin\Release\src\ILogger\netstandard2.0\Microsoft.Extensions.Logging.ApplicationInsights.dll'.
CA0052 : No targets were selected
```

https://stackoverflow.com/questions/46617261/enabling-code-analysis-for-net-core-2-0-project-results-ca0055-and-ca0052-error

> This error is caused by using an old version of Code Analysis with .NET Core. This old version is only for non-.NET Core applications.
The solution is to disable the old Code Analysis for .NET Core projects and install the new version of Code Analysis, which is now a NuGet package. (The reason you probably want to disable the old Code Analysis tool for your project and NOT uninstall it is so that you can still use the old Code Analysis with old .NET applications, such as .NET 4.5.)

To fix it, we need to remove `RunCodeAnalysis` from Common props and set it on the projects that need it.
