### PR TITLE
Update semantic version

### DIFF
--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -13,7 +13,7 @@
       Date when Semantic Version was changed. 
       Update for every public release.
     -->
-    <SemanticVersionDate>2018-08-01</SemanticVersionDate>
+    <SemanticVersionDate>2018-12-31</SemanticVersionDate>
     
     <PreReleaseVersionFileName>.PreReleaseVersion</PreReleaseVersionFileName>
     <PreReleaseVersionFilePath>$(MSBuildThisFileDirectory)$(PreReleaseVersionFileName)</PreReleaseVersionFilePath>


### PR DESCRIPTION
fixes test issue 

```
2018-12-31T21:18:18.4956638Z Failed   SdkVersionIsCorrect
2018-12-31T21:18:18.4957159Z Error Message:
2018-12-31T21:18:18.4957400Z  Assert.AreEqual failed. Expected:<sd:2.9.0-43936>. Actual:<sd:2.9.0-43935>. 
2018-12-31T21:18:18.4957473Z Stack Trace:
2018-12-31T21:18:18.4957574Z    at Microsoft.ApplicationInsights.TraceListener.Tests.ApplicationInsightsTraceListenerTests.SdkVersionIsCorrect() in E:\A\_work\182\s\test\Shared\ApplicationInsightsTraceListenerTests.cs:line 107
2018-12-31T21:18:18.4957662Z 
```

https://dev.azure.com/mseng/AppInsights/_build/results?buildId=8103125