### PR TITLE
Fix version comparison tests

### DIFF
--- a/test/CommonTestShared/SdkVersionHelper.cs
+++ b/test/CommonTestShared/SdkVersionHelper.cs
@@ -6,12 +6,12 @@
 
     public static class SdkVersionHelper
     {
-        public static string GetExpectedSdkVersion(string prefix)
+        public static string GetExpectedSdkVersion(string prefix, Type loggerType)
         {
 #if NET45 || NET46
-            string versionStr = typeof(SdkVersionHelper).Assembly.GetCustomAttributes(false).OfType<AssemblyFileVersionAttribute>().First().Version;
+            string versionStr = loggerType.Assembly.GetCustomAttributes(false).OfType<AssemblyFileVersionAttribute>().First().Version;
 #else
-            string versionStr = typeof(SdkVersionHelper).GetTypeInfo().Assembly.GetCustomAttributes<AssemblyFileVersionAttribute>().First().Version;
+            string versionStr = loggerType.GetTypeInfo().Assembly.GetCustomAttributes<AssemblyFileVersionAttribute>().First().Version;
 #endif
             string[] versionParts = new Version(versionStr).ToString().Split('.');
 

--- a/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceTelemetryModuleTests.cs
+++ b/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceTelemetryModuleTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ApplicationInsights.DiagnosticSourceListener.Tests
                 Assert.AreEqual(testDiagnosticSource.Name, telemetry.Properties["DiagnosticSource"]);
                 Assert.AreEqual(SeverityLevel.Information, telemetry.SeverityLevel);
                 Assert.AreEqual(1234.ToString(InvariantCulture), telemetry.Properties["Prop1"]);
-                string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "dsl:");
+                string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "dsl:", loggerType: typeof(DiagnosticSourceTelemetryModule));
                 Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
             }
         }

--- a/test/EventSourceListener.netcoreapp10.Tests/EventSourceTelemetryModuleTests.cs
+++ b/test/EventSourceListener.netcoreapp10.Tests/EventSourceTelemetryModuleTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Tests
                 Assert.AreEqual("Hey!", telemetry.Message);
                 Assert.AreEqual("Hey!", telemetry.Properties["information"]);
                 Assert.AreEqual(SeverityLevel.Information, telemetry.SeverityLevel);
-                string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "evl:");
+                string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "evl:", loggerType: typeof(EventSourceTelemetryModule));
                 Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
             }
         }
@@ -107,7 +107,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Tests
                 Assert.AreEqual("Hey!", telemetry.Properties["information"]);
                 Assert.AreEqual(SeverityLevel.Information, telemetry.SeverityLevel);
 
-                string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "evl:");
+                string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "evl:", loggerType: typeof(EventSourceTelemetryModule));
                 Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
             }
         }
@@ -159,7 +159,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener.Tests
                     Assert.AreEqual("Hey!", telemetry.Message);
                     Assert.AreEqual("Hey!", telemetry.Properties["message"]);
                     Assert.AreEqual(SeverityLevel.Information, telemetry.SeverityLevel);
-                    string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "evl:");
+                    string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "evl:", loggerType: typeof(EventSourceTelemetryModule));
                     Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
                 }
             }

--- a/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
+++ b/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
             var telemetry = (TraceTelemetry)sentItems[0];
             Assert.AreNotEqual(default(DateTimeOffset), telemetry.Context);
 
-            string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "log4net:");
+            string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "log4net:", loggerType: typeof(AppendableLogger));
             Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
         }
         

--- a/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
+++ b/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
@@ -137,7 +137,7 @@
 
             var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.First();
 
-            string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "nlog:");
+            string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "nlog:", loggerType: typeof(ApplicationInsightsTarget));
             Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
         }
 

--- a/test/Shared/ApplicationInsightsTraceListenerTests.cs
+++ b/test/Shared/ApplicationInsightsTraceListenerTests.cs
@@ -104,7 +104,7 @@
 
                 TraceTelemetry telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.First();
 
-                string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "sd:");
+                string expectedVersion = SdkVersionHelper.GetExpectedSdkVersion(prefix: "sd:", loggerType: typeof(ApplicationInsightsTraceListener));
                 Assert.AreEqual(expectedVersion, telemetry.Context.GetInternalContext().SdkVersion);
             }
         }


### PR DESCRIPTION
There is no point in comparing the version of test assembly with the version of logging assembly - they don't have to match. It causes random test failures.

This change calculates SDK internal version based on the real assembly version rather than test one.