### PR TITLE
Add myget feed to nuget.config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -7,5 +7,6 @@
     </config>
   <packageSources>
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="applicationinsights" value="https://www.myget.org/F/applicationinsights/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Otherwise it's not possible to test/build logging with appinsights that is not on nuget yet.