### PR TITLE
App Insights instrumentation Key Default Value

### DIFF
--- a/src/NLogTarget/ApplicationInsightsTarget.cs
+++ b/src/NLogTarget/ApplicationInsightsTarget.cs
@@ -122,11 +122,7 @@ namespace Microsoft.ApplicationInsights.NLogTarget
             }
             else if (!string.IsNullOrWhiteSpace(TelemetryConfiguration.Active.InstrumentationKey))
             {
-<<<<<<< HEAD
                 this.telemetryClient.Context.InstrumentationKey = TelemetryConfiguration.Active.InstrumentationKey;
-=======
-                this.telemetryClient.Context.InstrumentationKey = instrumentationKey;
->>>>>>> 3f27a399bc96de7ac906469c7c3afa29e477a9bd
             }
 
             this.telemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("nlog:");

--- a/src/NLogTarget/ApplicationInsightsTarget.cs
+++ b/src/NLogTarget/ApplicationInsightsTarget.cs
@@ -120,6 +120,10 @@ namespace Microsoft.ApplicationInsights.NLogTarget
             {
                 this.telemetryClient.Context.InstrumentationKey = instrumentationKey;
             }
+            else if (!string.IsNullOrWhiteSpace(TelemetryConfiguration.Active.InstrumentationKey))
+            {
+                this.telemetryClient.Context.InstrumentationKey = TelemetryConfiguration.Active.InstrumentationKey;
+            }
 
             this.telemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("nlog:");
         }


### PR DESCRIPTION
Default app insights instrumentation key to active configuration's instrumentation key if one is not already set. I was hitting an issue where it was not getting pulled from my project's ApplicationInsights.config, but the active TelemetryConfiguration held the correct instrumentation key.