### PR TITLE
default app insights instrumentation key to active configuration's in…

### DIFF
--- a/src/NLogTarget/ApplicationInsightsTarget.cs
+++ b/src/NLogTarget/ApplicationInsightsTarget.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ApplicationInsights.NLogTarget
 
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Implementation;
 
@@ -119,6 +120,10 @@ namespace Microsoft.ApplicationInsights.NLogTarget
             if (!string.IsNullOrWhiteSpace(instrumentationKey))
             {
                 this.telemetryClient.Context.InstrumentationKey = instrumentationKey;
+            }
+            else if (!string.IsNullOrWhiteSpace(TelemetryConfiguration.Active.InstrumentationKey))
+            {
+                this.telemetryClient.Context.InstrumentationKey = TelemetryConfiguration.Active.InstrumentationKey;
             }
 
             this.telemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("nlog:");


### PR DESCRIPTION
Default app insights instrumentation key to active configuration's instrumentation key if one is not already set. I was hitting an issue where it was not getting pulled from my project's ApplicationInsights.config, but the active TelemetryConfiguration held the correct instrumentation key.