### PR TITLE
ILogger - Exception.Message is populated as ExceptionTelemetry.Message, Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog 
 ### Version 2.10.0-beta4
 - Update Base SDK to version 2.10.0-beta4
-- [ILogger - If an exception is passed to log, then Exception.Message is populated as ExceptionTelemetry.Message. If TrackExceptionsAsExceptionTelemetry is false, then Exception.Message is stored as custom property "ExceptionMessage"](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/239)
+- [ILogger - If an exception is passed to log, then Exception.Message is populated as ExceptionTelemetry.Message. If TrackExceptionsAsExceptionTelemetry is false, then Exception.Message is stored as custom property "ExceptionMessage"](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/282)
 
 ### Version 2.9.1
 - Update Base SDK to version 2.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog 
+### Version 2.10.0-beta4
+- Update Base SDK to version 2.10.0-beta4
+- [ILogger - If an exception is passed to log, then Exception.Message is populated as ExceptionTelemetry.Message. If TrackExceptionsAsExceptionTelemetry is false, then Exception.Message is stored as custom property "ExceptionMessage"](https://github.com/Microsoft/ApplicationInsights-dotnet-logging/pull/239)
+
 ### Version 2.9.1
 - Update Base SDK to version 2.9.1
 

--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -6,14 +6,14 @@
       Update for every public release. 
     -->
     <SemanticVersionMajor>2</SemanticVersionMajor>
-    <SemanticVersionMinor>9</SemanticVersionMinor>
-    <SemanticVersionPatch>1</SemanticVersionPatch>
-    <PreReleaseMilestone></PreReleaseMilestone>
+    <SemanticVersionMinor>10</SemanticVersionMinor>
+    <SemanticVersionPatch>0</SemanticVersionPatch>
+    <PreReleaseMilestone>beta4</PreReleaseMilestone>
     <!-- 
       Date when Semantic Version was changed. 
       Update for every public release.
     -->
-    <SemanticVersionDate>2018-12-31</SemanticVersionDate>
+    <SemanticVersionDate>2018-04-26</SemanticVersionDate>
     
     <PreReleaseVersionFileName>.PreReleaseVersion</PreReleaseVersionFileName>
     <PreReleaseVersionFilePath>$(MSBuildThisFileDirectory)$(PreReleaseVersionFileName)</PreReleaseVersionFilePath>

--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -13,7 +13,7 @@
       Date when Semantic Version was changed. 
       Update for every public release.
     -->
-    <SemanticVersionDate>2018-04-26</SemanticVersionDate>
+    <SemanticVersionDate>2018-12-31</SemanticVersionDate>
     
     <PreReleaseVersionFileName>.PreReleaseVersion</PreReleaseVersionFileName>
     <PreReleaseVersionFilePath>$(MSBuildThisFileDirectory)$(PreReleaseVersionFileName)</PreReleaseVersionFilePath>

--- a/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
+++ b/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
@@ -38,7 +38,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/EtwCollector/EtwCollector.csproj
+++ b/src/EtwCollector/EtwCollector.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.41" />
   </ItemGroup>
 

--- a/src/EventSourceListener/EventSourceListener.csproj
+++ b/src/EventSourceListener/EventSourceListener.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/EventSourceListener/Properties/AssemblyInfo.cs
+++ b/src/EventSourceListener/Properties/AssemblyInfo.cs
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a539bb1d-29ff-48e8-8d6e-dfcc543dc2b4")]
 
-[assembly: InternalsVisibleTo("Microsoft.ApplicationInsights.EventSourceListener.Tests, PublicKey=" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.ApplicationInsights.EventSourceListener.NetCoreApp10.Tests, PublicKey=" + AssemblyInfo.PublicKey)]
 
 internal static class AssemblyInfo
 {

--- a/src/ILogger/ApplicationInsightsLogger.cs
+++ b/src/ILogger/ApplicationInsightsLogger.cs
@@ -86,13 +86,18 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
                         formatter(state, exception),
                         ApplicationInsightsLogger.GetSeverityLevel(logLevel));
                     this.PopulateTelemetry(traceTelemetry, state, eventId);
+                    if (exception != null)
+                    {
+                        traceTelemetry.Properties.Add("ExceptionMessage", exception.Message);
+                    }
+
                     this.telemetryClient.TrackTrace(traceTelemetry);
                 }
                 else
                 {
                     ExceptionTelemetry exceptionTelemetry = new ExceptionTelemetry(exception)
                     {
-                        Message = formatter(state, exception),
+                        Message = exception.Message,
                         SeverityLevel = ApplicationInsightsLogger.GetSeverityLevel(logLevel),
                     };
 

--- a/src/ILogger/ApplicationInsightsLogger.cs
+++ b/src/ILogger/ApplicationInsightsLogger.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
                         SeverityLevel = ApplicationInsightsLogger.GetSeverityLevel(logLevel),
                     };
 
+                    exceptionTelemetry.Properties.Add("FormattedMessage", formatter(state, exception));
                     this.PopulateTelemetry(exceptionTelemetry, state, eventId);
                     this.telemetryClient.TrackException(exceptionTelemetry);
                 }

--- a/src/ILogger/ILogger.csproj
+++ b/src/ILogger/ILogger.csproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Log4NetAppender/Log4NetAppender.csproj
+++ b/src/Log4NetAppender/Log4NetAppender.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/NLogTarget/NLogTarget.csproj
+++ b/src/NLogTarget/NLogTarget.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/TraceListener/TraceListener.csproj
+++ b/src/TraceListener/TraceListener.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceListener.netcoreapp1.Tests.csproj
+++ b/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceListener.netcoreapp1.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Microsoft.ApplicationInsights.DiagnosticSourceListener.Tests</RootNamespace>
-    <AssemblyName>Microsoft.ApplicationInsights.DiagnosticSourceListener.Tests</AssemblyName>
+    <AssemblyName>Microsoft.ApplicationInsights.DiagnosticSourceListener.NetCoreApp10.Tests</AssemblyName>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceListener.netcoreapp1.Tests.csproj
+++ b/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceListener.netcoreapp1.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EtwCollector.Net451.Tests/EtwCollector.Net451.Tests.csproj
+++ b/test/EtwCollector.Net451.Tests/EtwCollector.Net451.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.41" />
     <ProjectReference Include="..\..\src\EtwCollector\EtwCollector.csproj" />
     <Reference Include="System.Net.Http" />

--- a/test/EventSourceListener.netcoreapp10.Tests/EventSourceListener.netcoreapp10.Tests.csproj
+++ b/test/EventSourceListener.netcoreapp10.Tests/EventSourceListener.netcoreapp10.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EventSourceListener.netcoreapp10.Tests/EventSourceListener.netcoreapp10.Tests.csproj
+++ b/test/EventSourceListener.netcoreapp10.Tests/EventSourceListener.netcoreapp10.Tests.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.ApplicationInsights.EventSourceListener.Tests</RootNamespace>
-    <AssemblyName>Microsoft.ApplicationInsights.EventSourceListener.Tests</AssemblyName>
+    <AssemblyName>Microsoft.ApplicationInsights.EventSourceListener.NetCoreApp10.Tests</AssemblyName>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/test/ILogger.NetStandard.Tests/ILoggerIntegrationTests.cs
+++ b/test/ILogger.NetStandard.Tests/ILoggerIntegrationTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ApplicationInsights
             ILogger<ILoggerIntegrationTests> testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
 
             testLogger.LogInformation("Testing");
-            testLogger.LogError(new Exception("TestException"), "Exception");
+            testLogger.LogError(new Exception("ExceptionMessage"), "LoggerMessage");
             testLogger.LogInformation(new EventId(100, "TestEvent"), "TestingEvent");
             testLogger.LogCritical("Critical");
             testLogger.LogTrace("Trace");
@@ -65,7 +65,8 @@ namespace Microsoft.ApplicationInsights
             Assert.AreEqual(SeverityLevel.Verbose, (itemsReceived[6] as TraceTelemetry).SeverityLevel);
 
             Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
-            Assert.AreEqual("Exception", (itemsReceived[1] as ExceptionTelemetry).Message);
+            Assert.AreEqual("ExceptionMessage", (itemsReceived[1] as ExceptionTelemetry).Message);
+            Assert.AreEqual("LoggerMessage", (itemsReceived[1] as ExceptionTelemetry).Properties["{OriginalFormat}"]);
             Assert.AreEqual("TestingEvent", (itemsReceived[2] as TraceTelemetry).Message);
             Assert.AreEqual("Critical", (itemsReceived[3] as TraceTelemetry).Message);
             Assert.AreEqual("Trace", (itemsReceived[4] as TraceTelemetry).Message);
@@ -92,13 +93,14 @@ namespace Microsoft.ApplicationInsights
             ILogger<ILoggerIntegrationTests> testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
 
             testLogger.LogInformation("Testing");
-            testLogger.LogError(new Exception("TestException"), "Exception");
+            testLogger.LogError(new Exception("ExceptionMessage"), "LoggerMessage");
 
             Assert.IsInstanceOfType(itemsReceived[0], typeof(TraceTelemetry));
             Assert.IsInstanceOfType(itemsReceived[1], typeof(ExceptionTelemetry));
 
             Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
-            Assert.AreEqual("Exception", (itemsReceived[1] as ExceptionTelemetry).Message);
+            Assert.AreEqual("ExceptionMessage", (itemsReceived[1] as ExceptionTelemetry).Message);
+            Assert.AreEqual("LoggerMessage", (itemsReceived[1] as ExceptionTelemetry).Properties["{OriginalFormat}"]);
         }
 
         /// <summary>
@@ -119,7 +121,7 @@ namespace Microsoft.ApplicationInsights
             ILogger<ILoggerIntegrationTests> testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
 
             testLogger.LogInformation("Testing");
-            testLogger.LogError(new Exception("TestException"), "Exception");
+            testLogger.LogError(new Exception("ExceptionMessage"), "LoggerMessage");
 
             Assert.IsInstanceOfType(itemsReceived[0], typeof(TraceTelemetry));
             Assert.IsInstanceOfType(itemsReceived[1], typeof(TraceTelemetry));
@@ -128,7 +130,9 @@ namespace Microsoft.ApplicationInsights
             Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
 
             Assert.AreEqual(SeverityLevel.Error, (itemsReceived[1] as TraceTelemetry).SeverityLevel);
-            Assert.AreEqual("Exception", (itemsReceived[1] as TraceTelemetry).Message);
+            Assert.AreEqual("LoggerMessage", (itemsReceived[1] as TraceTelemetry).Message);
+            
+            Assert.AreEqual("ExceptionMessage", (itemsReceived[1] as TraceTelemetry).Properties["ExceptionMessage"]);
         }
 
         /// <summary>
@@ -154,7 +158,7 @@ namespace Microsoft.ApplicationInsights
                 using (testLogger.BeginScope<IReadOnlyCollection<KeyValuePair<string, object>>>(new Dictionary<string, object> { { "Key", "Value" } }))
                 {
                     testLogger.LogInformation("Testing");
-                    testLogger.LogError(new Exception("TestException"), "Exception");
+                    testLogger.LogError(new Exception("ExceptionMessage"), "LoggerMessage");
                 }
             }
 
@@ -165,7 +169,7 @@ namespace Microsoft.ApplicationInsights
             Assert.AreEqual("Value", (itemsReceived[1] as ISupportProperties).Properties["Key"]);
 
             Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
-            Assert.AreEqual("Exception", (itemsReceived[1] as ExceptionTelemetry).Message);
+            Assert.AreEqual("ExceptionMessage", (itemsReceived[1] as ExceptionTelemetry).Message);
         }
 
         /// <summary>
@@ -191,7 +195,7 @@ namespace Microsoft.ApplicationInsights
                 using (testLogger.BeginScope<IReadOnlyCollection<KeyValuePair<string, object>>>(new Dictionary<string, object> { { "Key", "Value" } }))
                 {
                     testLogger.LogInformation("Testing");
-                    testLogger.LogError(new Exception("TestException"), "Exception");
+                    testLogger.LogError(new Exception("ExceptionMessage"), "LoggerMessage");
                 }
             }
 
@@ -202,7 +206,7 @@ namespace Microsoft.ApplicationInsights
             Assert.IsFalse((itemsReceived[1] as ISupportProperties).Properties.ContainsKey("Key"));
 
             Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
-            Assert.AreEqual("Exception", (itemsReceived[1] as ExceptionTelemetry).Message);
+            Assert.AreEqual("ExceptionMessage", (itemsReceived[1] as ExceptionTelemetry).Message);
         }
 
         /// <summary>

--- a/test/ILogger.NetStandard.Tests/ILoggerIntegrationTests.cs
+++ b/test/ILogger.NetStandard.Tests/ILoggerIntegrationTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ApplicationInsights
 
             Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
             Assert.AreEqual("ExceptionMessage", (itemsReceived[1] as ExceptionTelemetry).Message);
-            Assert.AreEqual("LoggerMessage", (itemsReceived[1] as ExceptionTelemetry).Properties["{OriginalFormat}"]);
+            Assert.AreEqual("LoggerMessage", (itemsReceived[1] as ExceptionTelemetry).Properties["FormattedMessage"]);
             Assert.AreEqual("TestingEvent", (itemsReceived[2] as TraceTelemetry).Message);
             Assert.AreEqual("Critical", (itemsReceived[3] as TraceTelemetry).Message);
             Assert.AreEqual("Trace", (itemsReceived[4] as TraceTelemetry).Message);
@@ -100,7 +100,7 @@ namespace Microsoft.ApplicationInsights
 
             Assert.AreEqual("Testing", (itemsReceived[0] as TraceTelemetry).Message);
             Assert.AreEqual("ExceptionMessage", (itemsReceived[1] as ExceptionTelemetry).Message);
-            Assert.AreEqual("LoggerMessage", (itemsReceived[1] as ExceptionTelemetry).Properties["{OriginalFormat}"]);
+            Assert.AreEqual("LoggerMessage", (itemsReceived[1] as ExceptionTelemetry).Properties["FormattedMessage"]);
         }
 
         /// <summary>

--- a/test/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
+++ b/test/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
     <PackageReference Include="log4net" Version="2.0.7" />
     <ProjectReference Include="..\..\src\Log4NetAppender\Log4NetAppender.csproj" />
     <Reference Include="System.Net.Http" />

--- a/test/Log4NetAppender.NetCoreApp10.Tests/Log4NetAppender.NetCoreApp10.Tests.csproj
+++ b/test/Log4NetAppender.NetCoreApp10.Tests/Log4NetAppender.NetCoreApp10.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <ProjectReference Include="..\..\src\Log4NetAppender\Log4NetAppender.csproj" />
   </ItemGroup>

--- a/test/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
+++ b/test/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
     <PackageReference Include="NLog" Version="4.4.12" />
     <ProjectReference Include="..\..\src\NLogTarget\NLogTarget.csproj" />
     <Reference Include="System.Net.Http" />

--- a/test/NLogTarget.NetCoreApp10.Tests/NLogTarget.NetCoreApp10.Tests.csproj
+++ b/test/NLogTarget.NetCoreApp10.Tests/NLogTarget.NetCoreApp10.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
     <PackageReference Include="NLog" Version="4.5.0" />
     <ProjectReference Include="..\..\src\NLogTarget\NLogTarget.csproj" />
   </ItemGroup>

--- a/test/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
+++ b/test/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
     <PackageReference Include="log4net" Version="2.0.5" />
     <ProjectReference Include="..\..\src\TraceListener\TraceListener.csproj" />
     <Reference Include="System.Net.Http" />

--- a/test/TraceListener.netcoreapp10.Tests/TraceListener.netcoreapp10.Tests.csproj
+++ b/test/TraceListener.netcoreapp10.Tests/TraceListener.netcoreapp10.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
 

--- a/test/Xdt.Tests/Xdt.Tests.csproj
+++ b/test/Xdt.Tests/Xdt.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0-beta4" />
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
ILogger - If an exception is passed to log, then Exception.Message is populated as ExceptionTelemetry.Message. 

If TrackExceptionsAsExceptionTelemetry is false, then Exception.Message is stored as custom property "ExceptionMessage"

Foe example, consider the following log call.
testLogger.LogError(new Exception("ExceptionMessage"), "LoggerMessage");
The ExceptionTelemetry created will contain "ExceptionMessage" in its Message field. "LoggerMessage" will be in custom property "FormattedMessage"

If TrackExceptionsAsExceptionTelemetry is false, then TraceTelemetry is created, and "LoggerMessage" will be in its Message field. "ExceptionMessage" will be in custom property "ExceptionMessage"

Prior to this, when an exception is passed to log, its Exception.Message was not stored anywhere.


Also bumped and updated versions.
