### PR TITLE
fixes #295. Allows .Net 4.5 projects to use Microsoft.ApplicationInsi…

### DIFF
--- a/src/EtwCollector/EtwCollector.csproj
+++ b/src/EtwCollector/EtwCollector.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>net451</TargetFrameworks>
+    <TargetFrameworks>net45</TargetFrameworks>
 
     <!--https://docs.microsoft.com/en-us/nuget/schema/msbuild-targets-->
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>


### PR DESCRIPTION
fixes #295. Allows .Net 4.5 projects to use Microsoft.ApplicationInsights.EtwCollector